### PR TITLE
Add algorithm header include

### DIFF
--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -45,6 +45,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <climits>
+#include <algorithm>
 
 // Static variable definitions.
 const unsigned int RtApi::MAX_SAMPLE_RATES = 14;


### PR DESCRIPTION
Without algorithm header, Visual Studio complaints that std::max is not
declared and defined.
Including algorithm header resolves this issue.

It is related to issue #21 .
