### PR TITLE
Fix calloc-free mismatch

### DIFF
--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -3630,12 +3630,12 @@ public:
       outIndex_( 0 ) {}
 
   ~WasapiBuffer() {
-    delete buffer_;
+    free( buffer_ );
   }
 
   // sets the length of the internal ring buffer
   void setBufferSize( unsigned int bufferSize, unsigned int formatBytes ) {
-    delete buffer_;
+    free( buffer_ );
 
     buffer_ = ( char* ) calloc( bufferSize, formatBytes );
 


### PR DESCRIPTION
Use free() for allocated memory by calloc (not delete).
Deleting calloc-ed memory will become problem in the environment which
overrides global "operator delete" like some game engine.
