### PR TITLE
Fix ALSA underrun warning message

### DIFF
--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -8014,6 +8014,8 @@ void RtApiAlsa :: callbackEvent()
             errorStream_ << "RtApiAlsa::callbackEvent: error preparing device after underrun, " << snd_strerror( result ) << ".";
             errorText_ = errorStream_.str();
           }
+          else
+            errorText_ =  "RtApiAlsa::callbackEvent: audio write error, underrun.";
         }
         else {
           errorStream_ << "RtApiAlsa::callbackEvent: error, current state is " << snd_pcm_state_name( state ) << ", " << snd_strerror( result ) << ".";


### PR DESCRIPTION
This fixes underrun warning text in error callback for ALSA API.
In some circumstances a text was not set.
That caused a usage of previous text.