### PR TITLE
fix compile errors with -D__MACOSX_CORE__

### DIFF
--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -1406,7 +1406,6 @@ void RtApiCore :: closeStream( void )
 
   CoreHandle *handle = (CoreHandle *) stream_.apiHandle;
   if ( stream_.mode == OUTPUT || stream_.mode == DUPLEX ) {
-  if ( stream_.mode == OUTPUT || stream_.mode == DUPLEX ) {
     if (handle) {
       AudioObjectPropertyAddress property = { kAudioHardwarePropertyDevices,
         kAudioObjectPropertyScopeGlobal,


### PR DESCRIPTION
Hi.

```
$ clang -framework CoreAudio -framework CoreFoundation -D__MACOSX_CORE__ -lc++ RtAudio.cpp main.cpp
```

just after clone from github master, above command fails with compile errors.

```
RtAudio.cpp:1477:1: error: function definition is not allowed here
{
^
RtAudio.cpp:1518:1: error: function definition is not allowed here
{
^
RtAudio.cpp:1561:1: error: function definition is not allowed here
{
^
RtAudio.cpp:1581:1: error: function definition is not allowed here
{
^
...
```

these are caused by this duplecated line.
so, this PR deletes second line.

```
  if ( stream_.mode == OUTPUT || stream_.mode == DUPLEX ) {
  if ( stream_.mode == OUTPUT || stream_.mode == DUPLEX ) {
```

Regards.