### PR TITLE
Release lock if GetCurrentPosition from DS failed

### DIFF
--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -6438,6 +6438,7 @@ void RtApiDs :: callbackEvent()
       if ( FAILED( result ) ) {
         errorStream_ << "RtApiDs::callbackEvent: error (" << getErrorString( result ) << ") getting current write position!";
         errorText_ = errorStream_.str();
+        MUTEX_UNLOCK( &stream_.mutex );
         error( RtAudioError::SYSTEM_ERROR );
         return;
       }


### PR DESCRIPTION
Some situations like removing a device, the function GetCurrentPosition fails and, when return, does not unlock the mutex.