### PR TITLE
Revert "duplex test: 64 bit compatibility"

### DIFF
--- a/tests/duplex.cpp
+++ b/tests/duplex.cpp
@@ -55,7 +55,7 @@ int inout( void *outputBuffer, void *inputBuffer, unsigned int /*nBufferFrames*/
   // a simple buffer copy operation here.
   if ( status ) std::cout << "Stream over/underflow detected." << std::endl;
 
-  uint32_t *bytes = (uint32_t *) data;
+  unsigned int *bytes = (unsigned int *) data;
   memcpy( outputBuffer, inputBuffer, *bytes );
   return 0;
 }


### PR DESCRIPTION
This reverts commit f639653f5ecf98d3b093049435df5631d8eb0f44.

This change breaks the build with g++ 5.2.1, it complains:

    duplex.cpp:58:3: error: ‘uint32_t’ was not declared in this scope
       uint32_t *bytes = (uint32_t *) data;

It requires `#include <cstdint>`, which would require c++11 support, or `#include <stdint.h>`, which is known to be problematic on Windows.

Moreover, changing "unsigned int" to "uint32_t" shouldn't change anything on either 32- or 64-bit systems, since they are the same.  I tested it on an iMac running 10.8.5 and I did not get a Bus Error.  Can anyone verify that duplex crashes for them on a Mac without this change?  If so we should be able to find a solution that doesn't involve stdint.h, preferably.