### PR TITLE
Round floats by using roundf in order to round correctly.

### DIFF
--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -4974,7 +4974,7 @@ void RtApiWasapi::wasapiThread()
   }
 
   if ( stream_.mode == INPUT ) {
-    convBuffSize = ( size_t ) ( stream_.bufferSize * captureSrRatio ) * stream_.nDeviceChannels[INPUT] * formatBytes( stream_.deviceFormat[INPUT] );
+    convBuffSize = ( size_t ) std::roundf( stream_.bufferSize * captureSrRatio ) * stream_.nDeviceChannels[INPUT] * formatBytes( stream_.deviceFormat[INPUT] );
     deviceBuffSize = stream_.bufferSize * stream_.nDeviceChannels[INPUT] * formatBytes( stream_.deviceFormat[INPUT] );
   }
   else if ( stream_.mode == OUTPUT ) {


### PR DESCRIPTION
Rounding needs to be done like in this line: https://github.com/thestk/rtaudio/blob/master/RtAudio.cpp#L3886

I had a heap corruption when the Windows 10 system sound is set to 48kHz 16Bit and I setup RtAudio with 44.1kHz 16Bit which needs to be converted in [convertBufferWasapi]. The cast done in this line: https://github.com/thestk/rtaudio/blob/master/RtAudio.cpp#L4981 truncates and afterwards is missing one sample (which leads to heap corruption when free'ing the buffer on shut down). Therefore [roundf] is needed.

Please also check the other code paths like in [stream_.mode == INPUT]. I just corrected the one I am using. I am also not quite sure if this is the best way of fixing it. But you know the code best.