### PR TITLE
Support Debian/kFreeBSD and Debian/Hurd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -246,6 +246,11 @@ AS_CASE([$host],
     LIBS="-ldsound -lwinmm $LIBS"
   ])
   LIBS="-lole32 $LIBS"
+  ],
+  [*-*-kfreebsd*-gnu | *-*-gnu*],[
+  AS_IF([test "x$api" = "x" ], [
+    AC_MSG_ERROR(["$host" system has no default backend])
+  ])
   ],[
   AC_MSG_RESULT([none])
   # Default case for unknown realtime systems.


### PR DESCRIPTION
i finally got around making the build-system work with Debian/kFreeBSD and Debian/Hurd.
(i'm aware that these are probably not the most popular systems to do any serious realtime and/or audio work; but you never know...)

note that the patch is not very thoroughly tested.
It's simple, so i don't think it will break anything; but the actual builds on these platforms have only been scheduled yet, and not yet executed (well `kfreebsd-i386` has already succeeded); see [Debian's buildd](https://buildd.debian.org/status/package.php?p=rtaudio&suite=experimental) for the current status.