### PR TITLE
fix cmake build system missing variables in pkgconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 Makefile
 *.o
+build
 /config
 /configure
 /Makefile.in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ if (WIN32)
 endif (WIN32)
 
 cmake_policy(SET CMP0042 OLD)
+set(PACKAGE_VERSION 5.0.0)
 add_library(rtaudio SHARED ${rtaudio_SOURCES})
 add_library(rtaudio_static STATIC ${rtaudio_SOURCES})
 
@@ -128,9 +129,10 @@ endif (BUILD_TESTING)
 configure_file("rtaudio.pc.in" "rtaudio.pc" @ONLY)
 
 install(TARGETS rtaudio
-      LIBRARY DESTINATION lib
-      ARCHIVE DESTINATION lib
-      RUNTIME DESTINATION bin)
+      LIBRARY DESTINATION lib)
+
+install(TARGETS rtaudio_static
+      ARCHIVE DESTINATION lib)
 
 install(
     FILES RtAudio.h

--- a/rtaudio.pc.in
+++ b/rtaudio.pc.in
@@ -1,4 +1,4 @@
-prefix=@prefix@
+prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include/rtaudio        


### PR DESCRIPTION
Hi, I followed up on the comments in #106 I've made some changes that improve the CMake build.

- prefix in pkgconfig is now set according to the `CMAKE_INSTALL_PREFIX` variable
- the `PACKAGE_VERSION` variable was added for version control, it's now set to 5.0.0 and should be updated on future releases
- the `build` directory was added to `.gitignore`
The `pkgconfig` file is still missing requirements, but its current state should be enough for software that depends on RtAudio to find it using `pkconfig`.
If there's interest in the community I can do further work on that and on a `FindRtAudio.cmake` file to remove the dependency from `pkg-config` itself.

Hope this helps,
Claudio