### PR TITLE
Give more priority to PulseAudio api

### DIFF
--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -107,11 +107,11 @@ void RtAudio :: getCompiledApi( std::vector<RtAudio::Api> &apis )
 #if defined(__UNIX_JACK__)
   apis.push_back( UNIX_JACK );
 #endif
-#if defined(__LINUX_ALSA__)
-  apis.push_back( LINUX_ALSA );
-#endif
 #if defined(__LINUX_PULSE__)
   apis.push_back( LINUX_PULSE );
+#endif
+#if defined(__LINUX_ALSA__)
+  apis.push_back( LINUX_ALSA );
 #endif
 #if defined(__LINUX_OSS__)
   apis.push_back( LINUX_OSS );


### PR DESCRIPTION
Usually on Linux when PulseAudio is present ALSA would give errors when trying to open the device (due to it being already open by PulseAudio), so this gives more priority to PulseAudio.