### PR TITLE
autoconf: separate OS defaults and audio API testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,6 @@ matrix:
     env: HOST="" API="oss"
     compiler: clang
   - os: linux
-    env: HOST="--host=i686-w64-mingw32" API="winmm" CPPFLAGS="-Wno-unused-function"
-    compiler: gcc
-  - os: linux
-    env: HOST="--host=x86_64-w64-mingw32" API="winmm" CPPFLAGS="-Wno-unused-function"
-    compiler: gcc
-  - os: linux
     env: HOST="--host=i686-w64-mingw32" API="dsound" CPPFLAGS="-Wno-unused-function"
     compiler: gcc
   - os: linux

--- a/configure.ac
+++ b/configure.ac
@@ -198,13 +198,20 @@ AS_CASE(["$systems"], [*" pulse "*], [
 ])
 
 AS_CASE(["$systems"], [*" oss "*], [
-  AC_CHECK_LIB(ossaudio, main,
+  # libossaudio not required on some platforms (e.g. linux) so we
+  # don't break things if it's not found, but issue a warning when we
+  # are not sure (i.e. not on linux)
+  AS_CASE([$host], [*-*-linux*], [], [*], [need_ossaudio=yes])
+  AC_CHECK_LIB(ossaudio, main, [have_ossaudio=true],
+    AS_CASE(["$required"], [*" oss "*],
+      AS_IF([test "x$need_ossaudio" = xyes],
+        AC_MSG_WARN([RtAudio may require the ossaudio library]))))
+  AC_CHECK_HEADER(sys/soundcard.h,
     [api="$api -D__LINUX_OSS__"
      need_pthread=yes
-     found="$found OSS"
-     LIBS="-lossaudio $LIBS"],
+     found="$found OSS"],
     AS_CASE(["$required"], [*" oss "*],
-      AC_MSG_ERROR([RtAudio requires the ossaudio library])))
+      AC_MSG_ERROR([sys/soundcard.h not found])))
 ])
 
 AS_CASE(["$systems"], [*" jack "*], [

--- a/configure.ac
+++ b/configure.ac
@@ -169,11 +169,21 @@ AS_IF([test "x$systems" = "x"],
     [*-mingw32*],    [systems="asio ds wasapi jack"]
   ))
 
+# If any were specifically requested disabled, do it.
+AS_IF([test "x$with_jack"   = "xno"], [systems=`echo $systems|tr ' ' \\\\n|grep -v jack`])
+AS_IF([test "x$with_alsa"   = "xno"], [systems=`echo $systems|tr ' ' \\\\n|grep -v alsa`])
+AS_IF([test "x$with_pulse"  = "xno"], [systems=`echo $systems|tr ' ' \\\\n|grep -v pulse`])
+AS_IF([test "x$with_oss"    = "xno"], [systems=`echo $systems|tr ' ' \\\\n|grep -v oss`])
+AS_IF([test "x$with_core"   = "xno"], [systems=`echo $systems|tr ' ' \\\\n|grep -v core`])
+AS_IF([test "x$with_asio"   = "xno"], [systems=`echo $systems|tr ' ' \\\\n|grep -v asio`])
+AS_IF([test "x$with_dsound" = "xno"], [systems=`echo $systems|tr ' ' \\\\n|grep -v dsound`])
+AS_IF([test "x$with_wasapi" = "xno"], [systems=`echo $systems|tr ' ' \\\\n|grep -v wasapi`])
+systems=" `echo $systems|tr \\\\n ' '` "
+
 # For each audio system, check if it is selected and found.
 # Note: Order specified above is not necessarily respected. However,
 # *actual* priority is set at run-time, see RtAudio::openRtApi.
 # One AS_CASE per system, since they are not mutually-exclusive.
-systems=" $systems "
 
 AS_CASE(["$systems"], [*" alsa "*], [
   AC_CHECK_LIB(asound, snd_pcm_open,

--- a/configure.ac
+++ b/configure.ac
@@ -259,18 +259,20 @@ AS_CASE(["$systems"], [*" asio "*], [
 ])
 
 AS_CASE(["$systems"], [*" ds "*], [
-  api="$api -D__WINDOWS_DS__"
-  need_ole32=yes
-  found="$found DirectSound"
-  LIBS="-ldsound -lwinmm $LIBS"
+  AC_CHECK_HEADERS(mmsystem.h mmreg.h dsound.h,
+    [api="$api -D__WINDOWS_DS__"
+     need_ole32=yes
+     found="$found DirectSound"
+     LIBS="-ldsound -lwinmm $LIBS"])
 ])
 
 AS_CASE(["$systems"], [*" wasapi "*], [
-  api="$api -D__WINDOWS_WASAPI__"
-  CPPFLAGS="-I$srcdir/include $CPPFLAGS"
-  need_ole32=yes
-  found="$found WASAPI"
-  LIBS="-lwinmm -luuid -lksuser $LIBS"
+  AC_CHECK_HEADERS(windows.h audioclient.h avrt.h mmdeviceapi.h,
+    [api="$api -D__WINDOWS_WASAPI__"
+     CPPFLAGS="-I$srcdir/include $CPPFLAGS"
+     need_ole32=yes
+     found="$found WASAPI"
+     LIBS="-lwinmm -luuid -lksuser $LIBS"])
 ])
 
 AS_IF([test -n "$need_ole32"], [LIBS="-lole32 $LIBS"])

--- a/configure.ac
+++ b/configure.ac
@@ -287,7 +287,7 @@ AC_MSG_CHECKING([for audio API])
 # Error case: no known realtime systems found.
 AS_IF([test x"$api" = "x"], [
   AC_MSG_RESULT([none])
-  AC_MSG_ERROR([Unknown system type for realtime support!])
+  AC_MSG_ERROR([No known system type found for realtime support!])
 ], [
   AC_MSG_RESULT([$found])
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -38,9 +38,9 @@ use_asio=""
 
 # configure flags
 AC_ARG_ENABLE(debug, [AS_HELP_STRING([--enable-debug],[enable various debug output])])
-AC_ARG_WITH(jack, [AS_HELP_STRING([--with-jack], [choose JACK server support (mac and linux only)])])
+AC_ARG_WITH(jack, [AS_HELP_STRING([--with-jack], [choose JACK server support])])
 AC_ARG_WITH(alsa, [AS_HELP_STRING([--with-alsa], [choose native ALSA API support (linux only)])])
-AC_ARG_WITH(pulse, [AS_HELP_STRING([--with-pulse], [choose PulseAudio API support (linux only)])])
+AC_ARG_WITH(pulse, [AS_HELP_STRING([--with-pulse], [choose PulseAudio API support (unixes)])])
 AC_ARG_WITH(oss, [AS_HELP_STRING([--with-oss], [choose OSS API support (unixes)])])
 AC_ARG_WITH(core, [AS_HELP_STRING([--with-core], [choose CoreAudio API support (mac only)])])
 AC_ARG_WITH(asio, [AS_HELP_STRING([--with-asio], [choose ASIO API support (win32 only)])])

--- a/configure.ac
+++ b/configure.ac
@@ -216,12 +216,17 @@ AS_CASE(["$systems"], [*" oss "*], [
     AS_CASE(["$required"], [*" oss "*],
       AS_IF([test "x$need_ossaudio" = xyes],
         AC_MSG_WARN([RtAudio may require the ossaudio library]))))
-  AC_CHECK_HEADER(sys/soundcard.h,
+
+  # linux systems may have soundcard.h but *not* have OSS4 installed,
+  # we have to actually check if it exports OSS4 symbols
+  AC_CHECK_DECL(SNDCTL_SYSINFO,
     [api="$api -D__LINUX_OSS__"
      need_pthread=yes
      found="$found OSS"],
-    AS_CASE(["$required"], [*" oss "*],
-      AC_MSG_ERROR([sys/soundcard.h not found])))
+     AS_CASE(["$required"], [*" oss "*],
+       AC_MSG_ERROR([sys/soundcard.h not found]))
+    [],
+    [#include <sys/soundcard.h>])
 ])
 
 AS_CASE(["$systems"], [*" jack "*], [

--- a/configure.ac
+++ b/configure.ac
@@ -147,114 +147,126 @@ AC_CONFIG_LINKS( [doc/images/ccrma.gif:doc/images/ccrma.gif] )
 # Checks for package options and external software
 AC_CANONICAL_HOST
 
-AC_MSG_CHECKING([for audio API])
+# Aggregate options into a single string.
+AS_IF([test "x$with_jack"   = "xyes"], [systems="$systems jack"])
+AS_IF([test "x$with_alsa"   = "xyes"], [systems="$systems alsa"])
+AS_IF([test "x$with_pulse"  = "xyes"], [systems="$systems pulse"])
+AS_IF([test "x$with_oss"    = "xyes"], [systems="$systems oss"])
+AS_IF([test "x$with_core"   = "xyes"], [systems="$systems core"])
+AS_IF([test "x$with_asio"   = "xyes"], [systems="$systems asio"])
+AS_IF([test "x$with_ds"     = "xyes"], [systems="$systems ds"])
+AS_IF([test "x$with_wasapi" = "xyes"], [systems="$systems wasapi"])
+required=" $systems "
 
-AS_IF([test "x$with_jack" = "xyes"], [
-  AC_MSG_RESULT([using JACK])
-  AC_CHECK_LIB(jack, jack_client_open, , AC_MSG_ERROR([JACK support requires the jack library!]))
-  api="$api -D__UNIX_JACK__"
-  req="$req jack"
+# If none, assign defaults if any are known for this OS.
+# User must specified with-* options for any unknown OS.
+AS_IF([test "x$systems" = "x"],
+  AS_CASE([$host],
+    [*-*-netbsd*],   [systems="oss"],
+    [*-*-freebsd*],  [systems="oss"],
+    [*-*-linux*],    [systems="alsa pulse jack oss"],
+    [*-apple*],      [systems="core jack"],
+    [*-mingw32*],    [systems="asio ds wasapi jack"]
+  ))
+
+# For each audio system, check if it is selected and found.
+# Note: Order specified above is not necessarily respected. However,
+# *actual* priority is set at run-time, see RtAudio::openRtApi.
+# One AS_CASE per system, since they are not mutually-exclusive.
+systems=" $systems "
+
+AS_CASE(["$systems"], [*" alsa "*], [
+  AC_CHECK_LIB(asound, snd_pcm_open,
+    [api="$api -D__LINUX_ALSA__"
+     req="$req alsa"
+     need_pthread=yes
+     found="$found ALSA"
+     LIBS="-lasound $LIBS"],
+    AS_CASE(["$required"], [*" alsa "*],
+      AC_MSG_ERROR([ALSA support requires the asound library!])))
 ])
 
+AS_CASE(["$systems"], [*" pulse "*], [
+  AC_CHECK_LIB(pulse-simple, pa_simple_flush,
+    [api="$api -D__LINUX_PULSE__"
+     req="$req libpulse-simple"
+     need_pthread=yes
+     found="$found PulseAudio"
+     LIBS="-lpulse-simple $LIBS"],
+    AS_CASE(["$required"], [*" pulse "*],
+      AC_MSG_ERROR([PulseAudio support requires the pulse-simple library!])))
+])
 
-AS_CASE([$host],
-  [*-*-netbsd*],
-  AS_IF([test "x$api" = "x"], [
-    AC_MSG_RESULT([using OSS])
-    api="$api -D__LINUX_OSS__"
-    AC_CHECK_LIB(ossaudio, main, , AC_MSG_ERROR([RtAudio requires the ossaudio library]))
-    AC_CHECK_LIB(pthread, pthread_create, , AC_MSG_ERROR([RtAudio requires the pthread library!]))
-  ]),
-  [*-*-freebsd*],
-  AS_IF([test "x$api" = "x"], [
-    AC_MSG_RESULT([using OSS])
-    api="$api -D__LINUX_OSS__"
-    AC_CHECK_LIB(ossaudio, main, , AC_MSG_ERROR([RtAudio requires the ossaudio library]))
-    AC_CHECK_LIB(pthread, pthread_create, , AC_MSG_ERROR([RtAudio requires the pthread library!]))
-  ]),
-  [*-*-linux*], [
-  # Look for ALSA flag
-  AS_IF([test "x$with_alsa" = "xyes"], [
-    AC_MSG_RESULT([using ALSA])
-    api="$api -D__LINUX_ALSA__"
-    req="$req alsa"
-    AC_CHECK_LIB(asound, snd_pcm_open, , AC_MSG_ERROR([ALSA support requires the asound library!]))
-  ])
-  # Look for PULSE flag
-  AS_IF([test "x$with_pulse" = "xyes"], [
-    AC_MSG_RESULT([using PulseAudio])
-    api="$api -D__LINUX_PULSE__"
-    req="$req libpulse-simple"
-    AC_CHECK_LIB(pulse-simple, pa_simple_flush, , AC_MSG_ERROR([PulseAudio support requires the pulse-simple library!]))
-  ])
+AS_CASE(["$systems"], [*" oss "*], [
+  AC_CHECK_LIB(ossaudio, main,
+    [api="$api -D__LINUX_OSS__"
+     need_pthread=yes
+     found="$found OSS"
+     LIBS="-lossaudio $LIBS"],
+    AS_CASE(["$required"], [*" oss "*],
+      AC_MSG_ERROR([RtAudio requires the ossaudio library])))
+])
 
-  # Look for OSS flag
-  AS_IF([test "x$with_oss" = "xyes"], [
-    AC_MSG_RESULT([using OSS])
-    api="$api -D__LINUX_OSS__"
-  ])
+AS_CASE(["$systems"], [*" jack "*], [
+  AC_CHECK_LIB(jack, jack_client_open,
+    [api="$api -D__UNIX_JACK__"
+     req="$req jack"
+     need_pthread=yes
+     found="$found JACK"
+     LIBS="-ljack $LIBS"],
+    AS_CASE(["$required"], [*" jack "*],
+      AC_MSG_ERROR([JACK support requires the jack library!])))
+])
 
-  # If no audio api flags specified, use ALSA
-  AS_IF([test "x$api" = "x" ], [
-    AC_MSG_RESULT([using ALSA])
-    api="${api} -D__LINUX_ALSA__"
-    req="${req} alsa"
-    AC_CHECK_LIB(asound, snd_pcm_open, , AC_MSG_ERROR([ALSA support requires the asound library!]))
-  ])
-  AC_CHECK_LIB(pthread, pthread_create, , AC_MSG_ERROR([RtAudio requires the pthread library!]))
-  ],
-  [*-apple*],[
-  # Look for Core flag
-  AS_IF([test "x$with_core" = "xyes"], [
-    AC_MSG_RESULT([using CoreAudio])
-    api="$api -D__MACOSX_CORE__"
-    AC_CHECK_HEADER(CoreAudio/CoreAudio.h, [], [AC_MSG_ERROR([CoreAudio header files not found!])] )
-    LIBS="$LIBS -framework CoreAudio -framework CoreFoundation"
-  ])
-  # If no audio api flags specified, use CoreAudio
-  AS_IF([test "x$api" = "x" ], [
-    AC_MSG_RESULT([using CoreAudio])
-    api="${api} -D__MACOSX_CORE__"
-    AC_CHECK_HEADER(CoreAudio/CoreAudio.h,
-      [],
-      [AC_MSG_ERROR([CoreAudio header files not found!])] )
-    LIBS="LIBS -framework CoreAudio -framework CoreFoundation"
-  ])
-  AC_CHECK_LIB(pthread, pthread_create, , AC_MSG_ERROR([RtAudio requires the pthread library!]))
-  ],
-  [*-mingw32*],[
-  AS_IF([test "x$with_asio" = "xyes" ], [
-    AC_MSG_RESULT([using ASIO])
-    api="$api -D__WINDOWS_ASIO__"
-    use_asio=yes
-    CPPFLAGS="-I$srcdir/include $CPPFLAGS"
-  ])
-  # Look for DirectSound flag
-  AS_IF([test "x$with_ds" = "xyes" ], [
-    AC_MSG_RESULT([using DirectSound])
-    api="$api -D__WINDOWS_DS__"
-    LIBS="-ldsound -lwinmm $LIBS"
-  ])
-  # Look for WASAPI flag
-  AS_IF([test "x$with_wasapi" = "xyes"], [
-    AC_MSG_RESULT([using WASAPI])
-    api="$api -D__WINDOWS_WASAPI__"
-    LIBS="-lwinmm -luuid -lksuser $LIBS"
-    CPPFLAGS="-I$srcdir/include $CPPFLAGS"
-  ])
-  # If no audio api flags specified, use DS
-  AS_IF([test "x$api" = "x" ], [
-    AC_MSG_RESULT([using DirectSound])
-    api="$api -D__WINDOWS_DS__"
-    LIBS="-ldsound -lwinmm $LIBS"
-  ])
-  LIBS="-lole32 $LIBS"
-  ],[
+AS_CASE(["$systems"], [*" core "*], [
+  AC_CHECK_HEADER(CoreAudio/CoreAudio.h,
+    [api="$api -D__MACOSX_CORE__"
+     need_pthread=yes
+     found="$found CoreAudio",
+     LIBS="$LIBS -framework CoreAudio -framework CoreFoundation"],
+    AS_CASE(["$required"], [*" core "*],
+      AC_MSG_ERROR([CoreAudio header files not found!])))
+])
+
+AS_CASE(["$systems"], [*" asio "*], [
+  api="$api -D__WINDOWS_ASIO__"
+  use_asio=yes
+  CPPFLAGS="-I$srcdir/include $CPPFLAGS"
+  need_ole32=yes
+  found="$found ASIO"
+])
+
+AS_CASE(["$systems"], [*" ds "*], [
+  api="$api -D__WINDOWS_DS__"
+  need_ole32=yes
+  found="$found DirectSound"
+  LIBS="-ldsound -lwinmm $LIBS"
+])
+
+AS_CASE(["$systems"], [*" wasapi "*], [
+  api="$api -D__WINDOWS_WASAPI__"
+  CPPFLAGS="-I$srcdir/include $CPPFLAGS"
+  need_ole32=yes
+  found="$found WASAPI"
+  LIBS="-lwinmm -luuid -lksuser $LIBS"
+])
+
+AS_IF([test -n "$need_ole32"], [LIBS="-lole32 $LIBS"])
+
+AS_IF([test -n "$need_pthread"],[
+  AC_MSG_CHECKING([for pthread])
+  AC_CHECK_LIB(pthread, pthread_create, ,
+    AC_MSG_ERROR([RtAudio requires the pthread library!]))])
+
+AC_MSG_CHECKING([for audio API])
+
+# Error case: no known realtime systems found.
+AS_IF([test x"$api" = "x"], [
   AC_MSG_RESULT([none])
-  # Default case for unknown realtime systems.
   AC_MSG_ERROR([Unknown system type for realtime support!])
-  ]
-)
+], [
+  AC_MSG_RESULT([$found])
+])
 
 AM_CONDITIONAL( ASIO, [test "x${use_asio}" = "xyes" ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -154,7 +154,7 @@ AS_IF([test "x$with_pulse"  = "xyes"], [systems="$systems pulse"])
 AS_IF([test "x$with_oss"    = "xyes"], [systems="$systems oss"])
 AS_IF([test "x$with_core"   = "xyes"], [systems="$systems core"])
 AS_IF([test "x$with_asio"   = "xyes"], [systems="$systems asio"])
-AS_IF([test "x$with_ds"     = "xyes"], [systems="$systems ds"])
+AS_IF([test "x$with_dsound" = "xyes"], [systems="$systems ds"])
 AS_IF([test "x$with_wasapi" = "xyes"], [systems="$systems wasapi"])
 required=" $systems "
 


### PR DESCRIPTION
This is an idea for reorganizing the way APIs are detected at configure time.

Instead of wrapping up OS detection with expected APIs, and giving errors for unknown OS, first the `with` options are considered, then *only if there are none specified*, the OS is detected and some defaults are suggested.  Then, any APIs on that list are tested regarding found libraries.  APIs specified by `with` options are considered 'required' (error generated if not found), otherwise they are optional (not-found APIs are ignored).

This allows unknown OSs to still specify an API using `with` options, and makes it easier to manage which OSs are associated with which APIs, and also avoids repeating detection code for multiple OSs that support a single API.

This addresses #107, #110, #116.