### PR TITLE
make WASAPI instantiation errors non-fatal for older Windows

### DIFF
--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -3899,10 +3899,9 @@ RtApiWasapi::RtApiWasapi()
                          CLSCTX_ALL, __uuidof( IMMDeviceEnumerator ),
                          ( void** ) &deviceEnumerator_ );
 
-  if ( FAILED( hr ) ) {
-    errorText_ = "RtApiWasapi::RtApiWasapi: Unable to instantiate device enumerator";
-    error( RtAudioError::DRIVER_ERROR );
-  }
+  // If this runs on an old Windows, it will fail. Ignore and proceed.
+  if ( FAILED( hr ) )
+    deviceEnumerator_ = NULL;
 }
 
 //-----------------------------------------------------------------------------
@@ -3928,6 +3927,9 @@ unsigned int RtApiWasapi::getDeviceCount( void )
 
   IMMDeviceCollection* captureDevices = NULL;
   IMMDeviceCollection* renderDevices = NULL;
+
+  if ( !deviceEnumerator_ )
+    return 0;
 
   // Count capture devices
   errorText_.clear();


### PR DESCRIPTION
fixes #138 

Not raising a fatal error when WASAPI is not instantiable.
This allows Windows XP to fall back to DirectSound.