### PR TITLE
Fix ALSA CTL handle not being closed in the default case

### DIFF
--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -7162,6 +7162,7 @@ bool RtApiAlsa :: probeDeviceOpen( unsigned int device, StreamMode mode, unsigne
       }
       nDevices++;
     }
+    snd_ctl_close( chandle );
 
     if ( nDevices == 0 ) {
       // This should not happen because a check is made before this function is called.

--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -7157,6 +7157,7 @@ bool RtApiAlsa :: probeDeviceOpen( unsigned int device, StreamMode mode, unsigne
     if ( result == 0 ) {
       if ( nDevices == device ) {
         strcpy( name, "default" );
+        snd_ctl_close( chandle );
         goto foundDevice;
       }
       nDevices++;


### PR DESCRIPTION
In the case where the default audio device is loaded in probeDeviceOpen, the ALSA CTL handle was not being closed. In my case (running Debian 9), every call to snd_ctl_open created a PulseAudio thread in the back-end which only exits upon calling snd_ctl_close. So, every time a stream was opened, a dangling thread would be created. This edit seems to have fixed the issue.