### PR TITLE
avoid cmake error: "install Library TARGETS given no DESTINATION!"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,9 @@ endif (BUILD_TESTING)
 configure_file("rtaudio.pc.in" "rtaudio.pc" @ONLY)
 
 install(TARGETS rtaudio
-      LIBRARY DESTINATION lib)
+      LIBRARY DESTINATION lib
+      ARCHIVE DESTINATION lib
+      RUNTIME DESTINATION bin)
 
 install(TARGETS rtaudio_static
       ARCHIVE DESTINATION lib)


### PR DESCRIPTION
My platform is windows, my compiler mingw-w64.
I got this error on cmake <code>install Library TARGETS given no DESTINATION!</code> and after googling I arrived to this, which means reverting part of PR  #126 @claudiocabral 