### PR TITLE
Removed Unused Function

### DIFF
--- a/RtAudio.h
+++ b/RtAudio.h
@@ -874,7 +874,6 @@ public:
   void startStream( void );
   void stopStream( void );
   void abortStream( void );
-  long getStreamLatency( void );
 
   // This function is intended for internal use only.  It must be
   // public because it is called by the internal callback handler,
@@ -910,7 +909,6 @@ public:
   void startStream( void );
   void stopStream( void );
   void abortStream( void );
-  long getStreamLatency( void );
 
   // This function is intended for internal use only.  It must be
   // public because it is called by the internal callback handler,
@@ -945,7 +943,6 @@ public:
   void startStream( void );
   void stopStream( void );
   void abortStream( void );
-  long getStreamLatency( void );
 
   // This function is intended for internal use only.  It must be
   // public because it is called by the internal callback handler,
@@ -983,7 +980,6 @@ public:
   void startStream( void );
   void stopStream( void );
   void abortStream( void );
-  long getStreamLatency( void );
 
   // This function is intended for internal use only.  It must be
   // public because it is called by the internal callback handler,


### PR DESCRIPTION
There is a function that appears in most of the derived API classes, called `getStreamLatency`. Since it is implemented in the base class, and it is non-virtual, I take it that it was not meant to show up in the derived classes. This PR removes the prototype definition from the derived API classes. I tested the build with ALSA, JACK, and Pulse.