### PR TITLE
Appveyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,10 @@
+platform: x64
+configuration: Debug
+
+before_build:
+  - mkdir build
+  - cd build
+  - cmake ..
+
+build:
+  project: build\ALL_BUILD.vcxproj


### PR DESCRIPTION
I would suggest using Appveyor to test compilation for Windows. Appveyor is free but it can be kind of awkward to setup for organizations. Once you get it going, though, it's basically the same as Travis CI. This would help contributors like myself find out if a set of commits break a Windows build.