### PR TITLE
Add device id to audioprobe output

### DIFF
--- a/tests/audioprobe.cpp
+++ b/tests/audioprobe.cpp
@@ -46,6 +46,7 @@ int main()
     info = audio.getDeviceInfo(i);
 
     std::cout << "\nDevice Name = " << info.name << '\n';
+    std::cout << "Device ID = " << i << '\n';
     if ( info.probed == false )
       std::cout << "Probe Status = UNsuccessful\n";
     else {


### PR DESCRIPTION
Add device id to `audioprobe` output, useful when used in conjunction with a tool that requires the input of the `rtaudio` device id such as `jackTrip` PR: https://github.com/jcacerec/jacktrip/pull/36