### PR TITLE
rtaudio_c: add rtaudio_num_compiled_api()

### DIFF
--- a/rtaudio_c.cpp
+++ b/rtaudio_c.cpp
@@ -23,7 +23,7 @@ const rtaudio_api_t *rtaudio_compiled_api() {
 }
 
 extern "C" const unsigned int rtaudio_num_compiled_apis;
-unsigned int rtaudio_num_compiled_api(void) {
+unsigned int rtaudio_get_num_compiled_apis(void) {
   return rtaudio_num_compiled_apis;
 }
 

--- a/rtaudio_c.cpp
+++ b/rtaudio_c.cpp
@@ -22,6 +22,11 @@ const rtaudio_api_t *rtaudio_compiled_api() {
   return (rtaudio_api_t *) &rtaudio_compiled_apis[0];
 }
 
+extern "C" const unsigned int rtaudio_num_compiled_apis;
+const unsigned int rtaudio_num_compiled_api(void) {
+  return rtaudio_num_compiled_apis;
+}
+
 extern "C" const char* rtaudio_api_names[][2];
 const char *rtaudio_api_name(rtaudio_api_t api) {
     if (api < 0 || api >= RTAUDIO_API_NUM)

--- a/rtaudio_c.cpp
+++ b/rtaudio_c.cpp
@@ -23,7 +23,7 @@ const rtaudio_api_t *rtaudio_compiled_api() {
 }
 
 extern "C" const unsigned int rtaudio_num_compiled_apis;
-const unsigned int rtaudio_num_compiled_api(void) {
+unsigned int rtaudio_num_compiled_api(void) {
   return rtaudio_num_compiled_apis;
 }
 

--- a/rtaudio_c.h
+++ b/rtaudio_c.h
@@ -106,6 +106,7 @@ typedef struct rtaudio_stream_options {
 typedef struct rtaudio *rtaudio_t;
 
 RTAUDIOAPI const char *rtaudio_version(void);
+RTAUDIOAPI const unsigned int rtaudio_num_compiled_api(void);
 RTAUDIOAPI const rtaudio_api_t *rtaudio_compiled_api(void);
 RTAUDIOAPI const char *rtaudio_api_name(rtaudio_api_t api);
 RTAUDIOAPI const char *rtaudio_api_display_name(rtaudio_api_t api);

--- a/rtaudio_c.h
+++ b/rtaudio_c.h
@@ -106,7 +106,7 @@ typedef struct rtaudio_stream_options {
 typedef struct rtaudio *rtaudio_t;
 
 RTAUDIOAPI const char *rtaudio_version(void);
-RTAUDIOAPI const unsigned int rtaudio_num_compiled_api(void);
+RTAUDIOAPI unsigned int rtaudio_num_compiled_api(void);
 RTAUDIOAPI const rtaudio_api_t *rtaudio_compiled_api(void);
 RTAUDIOAPI const char *rtaudio_api_name(rtaudio_api_t api);
 RTAUDIOAPI const char *rtaudio_api_display_name(rtaudio_api_t api);

--- a/rtaudio_c.h
+++ b/rtaudio_c.h
@@ -106,7 +106,7 @@ typedef struct rtaudio_stream_options {
 typedef struct rtaudio *rtaudio_t;
 
 RTAUDIOAPI const char *rtaudio_version(void);
-RTAUDIOAPI unsigned int rtaudio_num_compiled_api(void);
+RTAUDIOAPI unsigned int rtaudio_get_num_compiled_apis(void);
 RTAUDIOAPI const rtaudio_api_t *rtaudio_compiled_api(void);
 RTAUDIOAPI const char *rtaudio_api_name(rtaudio_api_t api);
 RTAUDIOAPI const char *rtaudio_api_display_name(rtaudio_api_t api);


### PR DESCRIPTION
In the c implementation: The const unsigned int rtaudio_num_compiled_apis is not exported in ffi interfaces of modules, so it is here returned by a function.