### PR TITLE
Windows: include stdint.h for ThreadHandle.

### DIFF
--- a/RtAudio.h
+++ b/RtAudio.h
@@ -621,6 +621,7 @@ class RTAUDIO_DLL_PUBLIC RtAudio
   #endif
   #include <windows.h>
   #include <process.h>
+  #include <stdint.h>
 
   typedef uintptr_t ThreadHandle;
   typedef CRITICAL_SECTION StreamMutex;


### PR DESCRIPTION
Fixes #142.