### PR TITLE
Update lastTickTimestamp in startStream.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,6 +18,9 @@ if ASIO
 	include/asiodrivers.cpp \
 	include/asiolist.cpp \
 	include/iasiothiscallresolver.cpp
+
+# due to warning in asiolist.cpp
+%C%_librtaudio_la_CXXFLAGS += -Wno-error=unused-but-set-variable
 endif
 
 rtaudio_incdir = $(includedir)/rtaudio

--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -1541,6 +1541,10 @@ void RtApiCore :: startStream( void )
     return;
   }
 
+  #if defined( HAVE_GETTIMEOFDAY )
+  gettimeofday( &stream_.lastTickTimestamp, NULL );
+  #endif
+
   OSStatus result = noErr;
   CoreHandle *handle = (CoreHandle *) stream_.apiHandle;
   if ( stream_.mode == OUTPUT || stream_.mode == DUPLEX ) {
@@ -2499,6 +2503,10 @@ void RtApiJack :: startStream( void )
     return;
   }
 
+  #if defined( HAVE_GETTIMEOFDAY )
+  gettimeofday( &stream_.lastTickTimestamp, NULL );
+  #endif
+
   JackHandle *handle = (JackHandle *) stream_.apiHandle;
   int result = jack_activate( handle->client );
   if ( result ) {
@@ -3377,6 +3385,10 @@ void RtApiAsio :: startStream()
     error( RtAudioError::WARNING );
     return;
   }
+
+  #if defined( HAVE_GETTIMEOFDAY )
+  gettimeofday( &stream_.lastTickTimestamp, NULL );
+  #endif
 
   AsioHandle *handle = (AsioHandle *) stream_.apiHandle;
   ASIOError result = ASIOStart();
@@ -4550,6 +4562,10 @@ void RtApiWasapi::startStream( void )
     error( RtAudioError::WARNING );
     return;
   }
+
+  #if defined( HAVE_GETTIMEOFDAY )
+  gettimeofday( &stream_.lastTickTimestamp, NULL );
+  #endif
 
   // update stream state
   stream_.state = STREAM_RUNNING;
@@ -6392,6 +6408,10 @@ void RtApiDs :: startStream()
     return;
   }
 
+  #if defined( HAVE_GETTIMEOFDAY )
+  gettimeofday( &stream_.lastTickTimestamp, NULL );
+  #endif
+
   DsHandle *handle = (DsHandle *) stream_.apiHandle;
 
   // Increase scheduler frequency on lesser windows (a side-effect of
@@ -8084,6 +8104,10 @@ void RtApiAlsa :: startStream()
 
   MUTEX_LOCK( &stream_.mutex );
 
+  #if defined( HAVE_GETTIMEOFDAY )
+  gettimeofday( &stream_.lastTickTimestamp, NULL );
+  #endif
+
   int result = 0;
   snd_pcm_state_t state;
   AlsaHandle *apiInfo = (AlsaHandle *) stream_.apiHandle;
@@ -8654,6 +8678,10 @@ void RtApiPulse::startStream( void )
   }
 
   MUTEX_LOCK( &stream_.mutex );
+
+  #if defined( HAVE_GETTIMEOFDAY )
+  gettimeofday( &stream_.lastTickTimestamp, NULL );
+  #endif
 
   stream_.state = STREAM_RUNNING;
 
@@ -9638,6 +9666,10 @@ void RtApiOss :: startStream()
   }
 
   MUTEX_LOCK( &stream_.mutex );
+
+  #if defined( HAVE_GETTIMEOFDAY )
+  gettimeofday( &stream_.lastTickTimestamp, NULL );
+  #endif
 
   stream_.state = STREAM_RUNNING;
 

--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -4997,7 +4997,8 @@ void RtApiWasapi::wasapiThread()
   HMODULE AvrtDll = LoadLibrary( (LPCTSTR) "AVRT.dll" );
   if ( AvrtDll ) {
     DWORD taskIndex = 0;
-    TAvSetMmThreadCharacteristicsPtr AvSetMmThreadCharacteristicsPtr = ( TAvSetMmThreadCharacteristicsPtr ) GetProcAddress( AvrtDll, "AvSetMmThreadCharacteristicsW" );
+    TAvSetMmThreadCharacteristicsPtr AvSetMmThreadCharacteristicsPtr =
+      ( TAvSetMmThreadCharacteristicsPtr ) (void(*)()) GetProcAddress( AvrtDll, "AvSetMmThreadCharacteristicsW" );
     AvSetMmThreadCharacteristicsPtr( L"Pro Audio", &taskIndex );
     FreeLibrary( AvrtDll );
   }

--- a/RtAudio.h
+++ b/RtAudio.h
@@ -690,7 +690,6 @@ class S24 {
     return *this;
   }
 
-  S24( const S24& v ) { *this = v; }
   S24( const double& d ) { *this = (int) d; }
   S24( const float& f ) { *this = (int) f; }
   S24( const signed short& s ) { *this = (int) s; }

--- a/configure.ac
+++ b/configure.ac
@@ -259,7 +259,15 @@ AS_CASE(["$systems"], [*" asio "*], [
 ])
 
 AS_CASE(["$systems"], [*" ds "*], [
-  AC_CHECK_HEADERS(mmsystem.h mmreg.h dsound.h,
+  AC_CHECK_HEADERS(windows.h)
+  AC_CHECK_HEADERS(mmsystem.h mmreg.h dsound.h, [], [],
+[#ifdef HAVE_WINDOWS_H
+# include <windows.h>
+#endif])
+  AS_IF([test "x$ac_cv_header_windows_h" = xyes \
+      && test "x$ac_cv_header_mmsystem_h" = xyes \
+      && test "x$ac_cv_header_mmreg_h" = xyes \
+      && test "x$ac_cv_header_dsound_h" = xyes],
     [api="$api -D__WINDOWS_DS__"
      need_ole32=yes
      found="$found DirectSound"
@@ -267,7 +275,15 @@ AS_CASE(["$systems"], [*" ds "*], [
 ])
 
 AS_CASE(["$systems"], [*" wasapi "*], [
-  AC_CHECK_HEADERS(windows.h audioclient.h avrt.h mmdeviceapi.h,
+  AC_CHECK_HEADERS(windows.h)
+  AC_CHECK_HEADERS(audioclient.h avrt.h mmdeviceapi.h, [], [],
+[#ifdef HAVE_WINDOWS_H
+# include <windows.h>
+#endif])
+  AS_IF([test "x$ac_cv_header_windows_h" = xyes \
+      && test "x$ac_cv_header_audioclient_h" = xyes \
+      && test "x$ac_cv_header_avrt_h" = xyes \
+      && test "x$ac_cv_header_mmdeviceapi_h" = xyes],
     [api="$api -D__WINDOWS_WASAPI__"
      CPPFLAGS="-I$srcdir/include $CPPFLAGS"
      need_ole32=yes

--- a/configure.ac
+++ b/configure.ac
@@ -166,7 +166,9 @@ AS_IF([test "x$systems" = "x"],
     [*-*-freebsd*],  [systems="oss"],
     [*-*-linux*],    [systems="alsa pulse jack oss"],
     [*-apple*],      [systems="core jack"],
-    [*-mingw32*],    [systems="asio ds wasapi jack"]
+    [*-mingw32*],    [systems="asio ds wasapi jack"],
+    [*-mingw64*],    [systems="asio ds wasapi jack"],
+    [*-msys*],       [systems="asio ds wasapi jack"],
   ))
 
 # If any were specifically requested disabled, do it.

--- a/configure.ac
+++ b/configure.ac
@@ -154,7 +154,7 @@ AS_IF([test "x$with_pulse"  = "xyes"], [systems="$systems pulse"])
 AS_IF([test "x$with_oss"    = "xyes"], [systems="$systems oss"])
 AS_IF([test "x$with_core"   = "xyes"], [systems="$systems core"])
 AS_IF([test "x$with_asio"   = "xyes"], [systems="$systems asio"])
-AS_IF([test "x$with_dsound" = "xyes"], [systems="$systems ds"])
+AS_IF([test "x$with_dsound" = "xyes"], [systems="$systems dsound"])
 AS_IF([test "x$with_wasapi" = "xyes"], [systems="$systems wasapi"])
 required=" $systems "
 
@@ -166,9 +166,9 @@ AS_IF([test "x$systems" = "x"],
     [*-*-freebsd*],  [systems="oss"],
     [*-*-linux*],    [systems="alsa pulse jack oss"],
     [*-apple*],      [systems="core jack"],
-    [*-mingw32*],    [systems="asio ds wasapi jack"],
-    [*-mingw64*],    [systems="asio ds wasapi jack"],
-    [*-msys*],       [systems="asio ds wasapi jack"],
+    [*-mingw32*],    [systems="asio dsound wasapi jack"],
+    [*-mingw64*],    [systems="asio dsound wasapi jack"],
+    [*-msys*],       [systems="asio dsound wasapi jack"],
   ))
 
 # If any were specifically requested disabled, do it.
@@ -260,7 +260,7 @@ AS_CASE(["$systems"], [*" asio "*], [
   found="$found ASIO"
 ])
 
-AS_CASE(["$systems"], [*" ds "*], [
+AS_CASE(["$systems"], [*" dsound "*], [
   AC_CHECK_HEADERS(windows.h)
   AC_CHECK_HEADERS(mmsystem.h mmreg.h dsound.h, [], [],
 [#ifdef HAVE_WINDOWS_H


### PR DESCRIPTION
Fixes #144.

Added to each one because... shouldn't Windows apis use QueryPerformanceCounter instead of gettimeofday?

In any case perhaps with C++11 this can be replaced with std::chrono.