### PR TITLE
rename uninstall target to uninstall_rtaudio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,7 +302,7 @@ configure_file(
     "${CMAKE_CURRENT_BINARY_DIR}/RtAudioConfigUninstall.cmake" @ONLY)
 
 # Create uninstall target.
-add_custom_target(uninstall
+add_custom_target(uninstall_rtaudio
     COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/RtAudioConfigUninstall.cmake)
 
 install(


### PR DESCRIPTION
when creating a cmake with GLFW and RtAudio as submodules, there is a cmake complain about unistall target already being defined in GLFW
My solution was to rename uninstall to uninstall_rtaudio