### PR TITLE
cmake add SKIP_HAVE_GETTIMEOFDAY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ option(RTAUDIO_API_CORE "Build CoreAudio API" ${APPLE})
 # Check for functions
 include(CheckFunctionExists)
 check_function_exists(gettimeofday HAVE_GETTIMEOFDAY)
-if (HAVE_GETTIMEOFDAY)
+if (HAVE_GETTIMEOFDAY AND NOT SKIP_HAVE_GETTIMEOFDAY)
     add_definitions(-DHAVE_GETTIMEOFDAY)
 endif ()
 


### PR DESCRIPTION
by defining SKIP_HAVE_GETTIMEOFDAY in cmake we can avoid use HAVE_GETTIMEOFDAY even if we have it