### PR TITLE
Reduce CMake required version to 3.5.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Set minimum CMake required version for this project.
-cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 # Define a C++ project.
 project(RtAudio LANGUAGES CXX)


### PR DESCRIPTION
Recently the required CMake version was increased to 3.10. The CMake file in master does not require greater than version 3.0. This breaks compatibility with Ubuntu Xenial, Raspbian Stretch, and presumably many other GNU/Linux distros where the upstream CMake version that's available is greater than 3.0 but much less than 3.10. I have chosen 3.5 for this PR as it's what's required by Xenial, but in general the required version should be reduced. I have at least one project is broken because of this change in the most recent release. If this PR is merged I would ask for a small amendment release for those folks that rely on stable releases. Thanks for your consideration.