### PR TITLE
fixed ever appending line to RtAudioConfig.cmake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,9 +283,11 @@ set(RTAUDIO_CMAKE_DESTINATION share/rtaudio)
 # Create CMake configuration export file.
 if(NEED_PTHREAD)
   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/RtAudioConfig.cmake "find_package(Threads REQUIRED)\n")
+  file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/RtAudioConfig.cmake "include(\${CMAKE_CURRENT_LIST_DIR}/RtAudioTargets.cmake)")
+else()
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/RtAudioConfig.cmake "include(\${CMAKE_CURRENT_LIST_DIR}/RtAudioTargets.cmake)")
 endif()
 
-file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/RtAudioConfig.cmake "include(\${CMAKE_CURRENT_LIST_DIR}/RtAudioTargets.cmake)")
 
 # Install CMake configuration export file.
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/RtAudioConfig.cmake


### PR DESCRIPTION
When I tried to configure, a flag NEED_PTHREAD seems to be disabled and the line 
`  file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/RtAudioConfig.cmake "include(\${CMAKE_CURRENT_LIST_DIR}/RtAudioTargets.cmake)")`  was execute every configuration. Then `RtAudioConfig.cmake` became a stack of appended line even if I tried clean reconfigure in VSCode.