### PR TITLE
Change type of captureFlags to DWORD

### DIFF
--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -4941,7 +4941,7 @@ void RtApiWasapi::wasapiThread()
   // declare local stream variables
   RtAudioCallback callback = ( RtAudioCallback ) stream_.callbackInfo.callback;
   BYTE* streamBuffer = NULL;
-  unsigned long captureFlags = 0;
+  DWORD captureFlags = 0;
   unsigned int bufferFrameCount = 0;
   unsigned int numFramesPadding = 0;
   unsigned int convBufferSize = 0;


### PR DESCRIPTION
When compiling with WASAPI on my windows machine, the build fails since the type of a variable captureFlags (unsigned long) does not match the windows DWORD type (unsigned int) in a function call. Changing the captureFlags type to DWORD seems to be the most reliable fix for this issue since it ensures that captureFlags is processor independent.