### PR TITLE
Add rtaudio_error_type() method to retrieve RtAudioError::Type

### DIFF
--- a/rtaudio_c.h
+++ b/rtaudio_c.h
@@ -113,6 +113,7 @@ typedef int (*rtaudio_cb_t)(void *out, void *in, unsigned int nFrames,
     See \ref RtAudioError.
 */
 typedef enum rtaudio_error {
+  RTAUDIO_NO_ERROR = -1,           /*!< No error. */
   RTAUDIO_ERROR_WARNING,           /*!< A non-critical error. */
   RTAUDIO_ERROR_DEBUG_WARNING,     /*!< A non-critical error which might be useful for debugging. */
   RTAUDIO_ERROR_UNSPECIFIED,       /*!< The default, unspecified error type. */
@@ -219,6 +220,8 @@ RTAUDIOAPI const char *rtaudio_api_display_name(rtaudio_api_t api);
 RTAUDIOAPI rtaudio_api_t rtaudio_compiled_api_by_name(const char *name);
 
 RTAUDIOAPI const char *rtaudio_error(rtaudio_t audio);
+
+RTAUDIOAPI rtaudio_error_t rtaudio_error_type(rtaudio_t audio);
 
 //! Create an instance of struct rtaudio.
 RTAUDIOAPI rtaudio_t rtaudio_create(rtaudio_api_t api);


### PR DESCRIPTION
`rtaudio_c.h` defines the `rtaudio_error_t` enum, however it doesn’t appear to be used anywhere;  the various C functions only retrieve the error message string from `RtAudioError`.

This change set redefines the `rtaudio_t->has_error` member as `rtaudio_t->errtype`. The new member holds `rtaudio_error_t` values and is retrievable by the getter function `rtaudio_error_type()`.

These changes will allow for fine-grained error handling when using the C API.