### PR TITLE
Add wasapi shared mode period

### DIFF
--- a/RtAudio.h
+++ b/RtAudio.h
@@ -1064,6 +1064,8 @@ private:
   static DWORD WINAPI stopWasapiThread( void* wasapiPtr );
   static DWORD WINAPI abortWasapiThread( void* wasapiPtr );
   void wasapiThread();
+
+  static bool iaudioclient3_available;
 };
 
 #endif


### PR DESCRIPTION
Wasapi on win10 desktop and later can query the system shared mode mixer's period for less latency and less overhead by adjusting buffer size to accomodate it.