### PR TITLE
Provide the specific error in the error call back

### DIFF
--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -8324,6 +8324,7 @@ void RtApiAlsa :: callbackEvent()
     }
 
     if ( result < (int) stream_.bufferSize ) {
+      RtAudioError::Type specificErrorType = RtAudioError::WARNING;
       // Either an error or overrun occured.
       if ( result == -EPIPE ) {
         snd_pcm_state_t state = snd_pcm_state( handle[1] );

--- a/RtAudio.h
+++ b/RtAudio.h
@@ -843,7 +843,7 @@ protected:
   void verifyStream( void );
 
   //! Protected common error method to allow global control over error handling.
-  void error( RtAudioError::Type type );
+  void error( RtAudioError::Type type, RtAudioError::Type specificErrorTypeForCallBack=RtAudioError::WARNING);
 
   /*!
     Protected method used to perform format, channel number, and/or interleaving


### PR DESCRIPTION
Because the error type is confused with the mean to report it (either text output for warnings or exceptions for non-warnings), it might be useful to get the actual specific error code in the error callback.
For example, when an audio device is removed while processing, it is reported as a simple warning, where it permanently breaks the audio stream.

In this PR:
(-) This specific error type is currently implemented only for ALSA.
(+) This fix doesn't break other APIs.
(+) This require little code changes and can be done for other APIs later on.
(-) This is a dirty fix as it doesn't solve the confusion between the error type and the mean to report it, which would require more refactoring.

No offense if you close this PR without merge, this can simply be used for matter of discussion.
