### PR TITLE
asiolist.cpp: remove unused variable

### DIFF
--- a/include/asiolist.cpp
+++ b/include/asiolist.cpp
@@ -166,7 +166,6 @@ AsioDriverList::AsioDriverList ()
 	LPASIODRVSTRUCT	pdl;
 	LONG 			cr;
 	DWORD			index = 0;
-	BOOL			fin = FALSE;
 
 	numdrv		= 0;
 	lpdrvlist	= 0;
@@ -184,7 +183,6 @@ AsioDriverList::AsioDriverList ()
 #endif
 			lpdrvlist = newDrvStruct (hkEnum,keyname,0,lpdrvlist);
 		}
-		else fin = TRUE;
 	}
 	if (hkEnum) RegCloseKey(hkEnum);
 


### PR DESCRIPTION
That seems to cause MinGW build failures in debug builds, see microsoft/vcpkg#17617