### PR TITLE
Fix PulseAudio getDefaultOutputDevice() and getDefaultInputDevice()

### DIFF
--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -410,13 +410,25 @@ void RtApi :: openStream( RtAudio::StreamParameters *oParams,
 
 unsigned int RtApi :: getDefaultInputDevice( void )
 {
-  // Should be implemented in subclasses if possible.
+  // Should be reimplemented in subclasses if necessary.
+  for ( unsigned int i = 0; i < getDeviceCount(); i++ ) {
+    if ( getDeviceInfo( i ).isDefaultInput ) {
+      return i;
+    }
+  }
+
   return 0;
 }
 
 unsigned int RtApi :: getDefaultOutputDevice( void )
 {
-  // Should be implemented in subclasses if possible.
+  // Should be reimplemented in subclasses if necessary.
+  for ( unsigned int i = 0; i < getDeviceCount(); i++ ) {
+    if ( getDeviceInfo( i ).isDefaultOutput ) {
+      return i;
+    }
+  }
+
   return 0;
 }
 
@@ -4520,34 +4532,6 @@ Exit:
     error( errorType );
   return info;
 }
-
-//-----------------------------------------------------------------------------
-
-unsigned int RtApiWasapi::getDefaultOutputDevice( void )
-{
-  for ( unsigned int i = 0; i < getDeviceCount(); i++ ) {
-    if ( getDeviceInfo( i ).isDefaultOutput ) {
-      return i;
-    }
-  }
-
-  return 0;
-}
-
-//-----------------------------------------------------------------------------
-
-unsigned int RtApiWasapi::getDefaultInputDevice( void )
-{
-  for ( unsigned int i = 0; i < getDeviceCount(); i++ ) {
-    if ( getDeviceInfo( i ).isDefaultInput ) {
-      return i;
-    }
-  }
-
-  return 0;
-}
-
-//-----------------------------------------------------------------------------
 
 void RtApiWasapi::closeStream( void )
 {

--- a/RtAudio.h
+++ b/RtAudio.h
@@ -1027,8 +1027,6 @@ public:
   RtAudio::Api getCurrentApi( void ) override { return RtAudio::WINDOWS_WASAPI; }
   unsigned int getDeviceCount( void ) override;
   RtAudio::DeviceInfo getDeviceInfo( unsigned int device ) override;
-  unsigned int getDefaultOutputDevice( void ) override;
-  unsigned int getDefaultInputDevice( void ) override;
   void closeStream( void ) override;
   void startStream( void ) override;
   void stopStream( void ) override;


### PR DESCRIPTION
On all Linux PulseAudio systems, calling `RtAudio::getDefaultOutputDevice()` with the PulseAudio backend returns device 0. This is because `RtApiPulse::getDefaultOutputDevice()` is not defined and calling it invokes the base-class method `RtApi::getDefaultOutputDevice()`, which is a placeholder which always returns 0. But on computers where the default input/output devices don't share the same name, this is an input-only device which cannot be used as output, meaning the returned default output device cannot be used to open a stream.  (getDefaultInputDevice() may also be wrong in rare cases. Details on why these happen are at #295.)

The idea I came up with was to loop over `RtApi::getDeviceInfo()` and return the (hopefully exactly 1) device labeled as a default. To my surprise, this code was already implemented... in RtApiWasapi only.

https://github.com/thestk/rtaudio/blob/48d60dbc9f578df8552f6dfa000fc26bec1f8232/RtAudio.cpp#L4526-L4548

## Outdated

To fix this issue, I extracted this logic to `getDefaultInputDeviceImpl` and `getDefaultOutputDeviceImpl` functions and added overriding methods `RtApiPulse::getDefaultOutputDevice()` and `RtApiPulse::getDefaultInputDevice()` which delegated to the extracted looping functions. This fixes the behavior on PulseAudio on my machine.

What I'm confused about is why the base class `RtApi::getDefaultOutputDevice()` doesn't loop over all devices by default. I have a hunch that making it do so would fix other audio backends as well. It appears that ALSA also has issues calculating the default device, looking at https://github.com/thestk/rtaudio/issues/224 and https://github.com/thestk/rtaudio/issues/270. However I haven't tested calling my new functions in ALSA, and I don't know if this new logic will fix/break/slow down other APIs aside from Pulse and ALSA. (WASAPI's behavior is unchanged, and DirectSound overrides `getDefaultOutputDevice` to always return device 0, even if the base class is changed. The other APIs will change their behavior.)

## Update (2021-06-23)

I force-pushed the branch to change RtApi::getDefaultInputDevice() and RtApi::getDefaultOutputDevice() to properly query the default devices. This implementation is used by all RtApi subclasses unless they override the methods. Currently, RtApiDs (DirectSound) overrides both methods to return 0, and RtApiCore (Core Audio) overrides them with Mac-specific code.

Fixes #295.