### PR TITLE
Add Meson build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,9 +28,11 @@ if get_option('oss') == true
 endif
 
 pulse_dep = dependency('libpulse', required: get_option('pulse'))
-if pulse_dep.found()
+pulsesimple_dep = dependency('libpulse-simple', required: get_option('pulse'))
+if pulse_dep.found() and pulsesimple_dep.found()
 	defines += '-D__LINUX_PULSE__'
 	deps += pulse_dep
+	deps += pulsesimple_dep
 endif
 
 core_dep = dependency('appleframeworks', modules: ['CoreAudio', 'CoreFoundation'], required: get_option('core'))

--- a/meson.build
+++ b/meson.build
@@ -3,6 +3,8 @@ project('rtaudio', 'cpp')
 src = ['RtAudio.cpp']
 incdir = include_directories('include')
 
+install_headers('RtAudio.h')
+
 compiler = meson.get_compiler('cpp')
 
 deps = []

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,70 @@
+project('rtaudio', 'cpp')
+
+src = ['RtAudio.cpp']
+incdir = include_directories('include')
+
+compiler = meson.get_compiler('cpp')
+
+deps = []
+defines = []
+deps += dependency('threads')
+
+alsa_dep = dependency('alsa', required: get_option('alsa'))
+if alsa_dep.found()
+	defines += '-D__LINUX_ALSA__'
+	deps += alsa_dep
+endif
+
+jack_dep = dependency('jack', required: get_option('jack'))
+if jack_dep.found()
+	defines += '-D__UNIX_JACK__'
+	deps += jack_dep
+endif
+
+if get_option('oss') == true
+	defines += '-D__LINUX_OSS__'
+endif
+
+pulse_dep = dependency('libpulse', required: get_option('pulse'))
+if pulse_dep.found()
+	defines += '-D__LINUX_PULSE__'
+	deps += pulse_dep
+endif
+
+core_dep = dependency('appleframeworks', modules: ['CoreAudio', 'CoreFoundation'], required: get_option('core'))
+if core_dep.found()
+	defines += '-D__MACOSX_CORE__'
+	deps += core_dep
+endif
+
+dsound_dep = compiler.find_library('dsound', required: get_option('dsound'))
+if dsound_dep.found()
+	defines += '-D__WINDOWS_DS__'
+	deps += dsound_dep
+endif
+
+if get_option('wasapi') == true
+	deps += compiler.find_library('mfplat', required: true)
+	deps += compiler.find_library('mfuuid', required: true)
+	deps += compiler.find_library('ksuser', required: true)
+	deps += compiler.find_library('wmcodecdspuuid', required: true)
+	defines += '-D__WINDOWS_WASAPI__'
+endif
+
+if get_option('asio') == true
+	src += ['asio.cpp',
+		'asiolist.cpp',
+		'asiodrivers.cpp',
+		'iasiothiscallresolver.cpp']
+	defines += '-D__WINDOWS_ASIO__'
+endif
+
+
+if host_machine.system() == 'windows'
+	deps += compiler.find_library('ole32', required: true)
+	deps += compiler.find_library('winmm', required: true)
+endif
+
+rtaudio = library('rtaudio', src, include_directories: incdir, dependencies: deps)
+rtaudio_dep = declare_dependency(include_directories : incdir,
+  link_with : rtaudio)

--- a/meson.build
+++ b/meson.build
@@ -68,6 +68,6 @@ if host_machine.system() == 'windows'
 endif
 
 rtaudio = library('rtaudio', src, include_directories: incdir, dependencies: deps)
-rtaudio_dep = declare_dependency(include_directories : incdir,
+rtaudio_dep = declare_dependency(include_directories : '.',
   link_with : rtaudio)
 meson.override_dependency('rtaudio', rtaudio_dep)

--- a/meson.build
+++ b/meson.build
@@ -54,10 +54,10 @@ if get_option('wasapi') == true
 endif
 
 if get_option('asio') == true
-	src += ['asio.cpp',
-		'asiolist.cpp',
-		'asiodrivers.cpp',
-		'iasiothiscallresolver.cpp']
+	src += ['include/asio.cpp',
+		'include/asiolist.cpp',
+		'include/asiodrivers.cpp',
+		'include/iasiothiscallresolver.cpp']
 	defines += '-D__WINDOWS_ASIO__'
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -67,7 +67,7 @@ if host_machine.system() == 'windows'
 	deps += compiler.find_library('winmm', required: true)
 endif
 
-rtaudio = library('rtaudio', src, include_directories: incdir, dependencies: deps)
+rtaudio = library('rtaudio', src, include_directories: incdir, cpp_args: defines, dependencies: deps)
 rtaudio_dep = declare_dependency(include_directories : '.',
   link_with : rtaudio)
 meson.override_dependency('rtaudio', rtaudio_dep)

--- a/meson.build
+++ b/meson.build
@@ -68,3 +68,4 @@ endif
 rtaudio = library('rtaudio', src, include_directories: incdir, dependencies: deps)
 rtaudio_dep = declare_dependency(include_directories : incdir,
   link_with : rtaudio)
+meson.override_dependency('rtaudio', rtaudio_dep)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,8 @@
+option('jack', type : 'feature', value : 'auto', description: 'Build with JACK Backend')
+option('alsa', type : 'feature', value : 'auto', description: 'Build with ALSA Backend')
+option('pulse', type : 'feature', value : 'auto', description: 'Build with Pulseaudio Backend')
+option('oss', type : 'boolean', value : 'false', description: 'Build with OSS Backend')
+option('core', type : 'feature', value : 'auto', description: 'Build with CoreAudio Backend')
+option('dsound', type : 'feature', value : 'auto', description: 'Build with DirectSound Backend')
+option('asio', type : 'boolean', value : 'false', description: 'Build with ASIO Backend')
+option('wasapi', type : 'boolean', value : 'false', description: 'Build with WASAPI Backend')


### PR DESCRIPTION
When building JackTrip I've used RtAudio as a cmake subproject in meson. I had to handle a lot of dependency things that should actually be handled by the subproject. So I decided to write meson build files for RtAudio. This simplifies a lot for me and I got rid of some linking errors on Windows. Additionally there would be the possibility to add RtAudio to the [WrapDB](https://wrapdb.mesonbuild.com/).

[This](https://github.com/jacktrip/jacktrip/pull/301) is the corresponding change in JackTrip.