### PR TITLE
Meson improvements

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('rtaudio', 'cpp', default_options: ['warning_level=3'])
+project('RtAudio', 'cpp', default_options: ['warning_level=3'])
 
 src = ['RtAudio.cpp', 'rtaudio_c.cpp']
 incdir = include_directories('include')

--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,10 @@ deps = []
 defines = []
 deps += dependency('threads')
 
+if compiler.has_function('gettimeofday', prefix: '#include <sys/time.h>')
+	defines += '-DHAVE_GETTIMEOFDAY'
+endif
+
 alsa_dep = dependency('alsa', required: get_option('alsa'))
 if alsa_dep.found()
 	defines += '-D__LINUX_ALSA__'

--- a/meson.build
+++ b/meson.build
@@ -9,11 +9,16 @@ compiler = meson.get_compiler('cpp')
 
 deps = []
 defines = []
-deps += dependency('threads')
 
 if compiler.has_function('gettimeofday', prefix: '#include <sys/time.h>')
 	defines += '-DHAVE_GETTIMEOFDAY'
 endif
+
+if get_option('debug') == true
+	defines += '-D__RTAUDIO_DEBUG__'
+endif
+
+deps += dependency('threads')
 
 alsa_dep = dependency('alsa', required: get_option('alsa'))
 if alsa_dep.found()

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('rtaudio', 'cpp')
+project('rtaudio', 'cpp', default_options: ['warning_level=3'])
 
 src = ['RtAudio.cpp', 'rtaudio_c.cpp']
 incdir = include_directories('include')

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project('RtAudio', 'cpp', default_options: ['warning_level=3'])
 src = ['RtAudio.cpp', 'rtaudio_c.cpp']
 incdir = include_directories('include')
 
-install_headers('RtAudio.h', 'rtaudio_c.h')
+install_headers('RtAudio.h', 'rtaudio_c.h', subdir: 'rtaudio')
 
 compiler = meson.get_compiler('cpp')
 

--- a/meson.build
+++ b/meson.build
@@ -73,3 +73,12 @@ rtaudio = library('rtaudio', src, include_directories: incdir, cpp_args: defines
 rtaudio_dep = declare_dependency(include_directories : '.',
   link_with : rtaudio)
 meson.override_dependency('rtaudio', rtaudio_dep)
+
+summary({'ALSA': alsa_dep.found(),
+	'OSS': get_option('oss'),
+	'JACK': jack_dep.found(),
+	'PulseAudio': pulse_dep.found() and pulsesimple_dep.found(),
+	'CoreAudio': core_dep.found(),
+	'DirectAudio': dsound_dep.found(),
+	'WASAPI': get_option('wasapi'),
+	'ASIO': get_option('asio')}, bool_yn: true, section: 'Audio Backends')

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ install_headers('RtAudio.h', 'rtaudio_c.h')
 compiler = meson.get_compiler('cpp')
 
 deps = []
-defines = []
+defines = ['-DRTAUDIO_EXPORT']
 
 if compiler.has_function('gettimeofday', prefix: '#include <sys/time.h>')
 	defines += '-DHAVE_GETTIMEOFDAY'

--- a/meson.build
+++ b/meson.build
@@ -1,9 +1,9 @@
 project('rtaudio', 'cpp')
 
-src = ['RtAudio.cpp']
+src = ['RtAudio.cpp', 'rtaudio_c.cpp']
 incdir = include_directories('include')
 
-install_headers('RtAudio.h')
+install_headers('RtAudio.h', 'rtaudio_c.h')
 
 compiler = meson.get_compiler('cpp')
 


### PR DESCRIPTION
This adds a summary about which audio backends get compiled. It gets also shown in the summary of superprojects (like JackTrip). It looks like this but with color:
```
RtAudio undefined

  Audio Backends
           ALSA: YES
            OSS: NO
           JACK: YES
     PulseAudio: YES
      CoreAudio: NO
    DirectAudio: NO
         WASAPI: NO
           ASIO: NO
```

Other changes should lead to a build that is more similar to the cmake one. The last things that are missing are setting the project version and pkgconfig as well as cmake file generation.