### PR TITLE
Let Meson generate pkgconfig file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -78,7 +78,7 @@ if host_machine.system() == 'windows'
 	deps += compiler.find_library('winmm', required: true)
 endif
 
-rtaudio = library('rtaudio', src, include_directories: incdir, cpp_args: defines, dependencies: deps)
+rtaudio = library('rtaudio', src, include_directories: incdir, cpp_args: defines, dependencies: deps, install: true)
 rtaudio_dep = declare_dependency(include_directories : '.',
   link_with : rtaudio)
 meson.override_dependency('rtaudio', rtaudio_dep)

--- a/meson.build
+++ b/meson.build
@@ -38,11 +38,9 @@ if get_option('oss') == true
 	defines += '-D__LINUX_OSS__'
 endif
 
-pulse_dep = dependency('libpulse', required: get_option('pulse'))
 pulsesimple_dep = dependency('libpulse-simple', required: get_option('pulse'))
-if pulse_dep.found() and pulsesimple_dep.found()
+if pulsesimple_dep.found()
 	defines += '-D__LINUX_PULSE__'
-	deps += pulse_dep
 	deps += pulsesimple_dep
 endif
 
@@ -92,7 +90,7 @@ pkg.generate(rtaudio,
 summary({'ALSA': alsa_dep.found(),
 	'OSS': get_option('oss'),
 	'JACK': jack_dep.found(),
-	'PulseAudio': pulse_dep.found() and pulsesimple_dep.found(),
+	'PulseAudio': pulsesimple_dep.found(),
 	'CoreAudio': core_dep.found(),
 	'DirectAudio': dsound_dep.found(),
 	'WASAPI': get_option('wasapi'),

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,9 @@
-project('RtAudio', 'cpp', version: '5.1.0', default_options: ['warning_level=3', 'c_std=c99', 'cpp_std=c++11'])
+project('RtAudio', 'cpp',
+	version: '5.1.0',
+	default_options: ['warning_level=3',
+			'c_std=c99',
+			'cpp_std=c++11',
+			'default_library=both'])
 
 fs = import('fs')
 pkg = import('pkgconfig')

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,6 @@
-project('RtAudio', 'cpp', default_options: ['warning_level=3', 'c_std=c99', 'cpp_std=c++11'])
+project('RtAudio', 'cpp', version: '5.1.0', default_options: ['warning_level=3', 'c_std=c99', 'cpp_std=c++11'])
+
+pkg = import('pkgconfig')
 
 src = ['RtAudio.cpp', 'rtaudio_c.cpp']
 incdir = include_directories('include')
@@ -82,6 +84,10 @@ rtaudio = library('rtaudio', src, include_directories: incdir, cpp_args: defines
 rtaudio_dep = declare_dependency(include_directories : '.',
   link_with : rtaudio)
 meson.override_dependency('rtaudio', rtaudio_dep)
+
+pkg.generate(rtaudio,
+	description: 'RtAudio - a set of C++ classes that provide a common API for realtime audio input/output',
+	subdirs: 'rtaudio')
 
 summary({'ALSA': alsa_dep.found(),
 	'OSS': get_option('oss'),

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,20 @@
 project('RtAudio', 'cpp', version: '5.1.0', default_options: ['warning_level=3', 'c_std=c99', 'cpp_std=c++11'])
 
+fs = import('fs')
 pkg = import('pkgconfig')
+
+ac_file = fs.read('configure.ac').strip().split('\n')
+foreach line : ac_file
+	if line.startswith('m4_define([lt_current],')
+		lt_current = line.substring(-2,-1)
+	elif line.startswith('m4_define([lt_revision],')
+		lt_revision = line.substring(-2,-1)
+	elif line.startswith('m4_define([lt_age],')
+		lt_age = line.substring(-2,-1)
+	endif
+endforeach
+
+so_version = '.'.join([lt_current,lt_revision,lt_age])
 
 src = ['RtAudio.cpp', 'rtaudio_c.cpp']
 incdir = include_directories('include')
@@ -78,7 +92,12 @@ if host_machine.system() == 'windows'
 	deps += compiler.find_library('winmm', required: true)
 endif
 
-rtaudio = library('rtaudio', src, include_directories: incdir, cpp_args: defines, dependencies: deps, install: true)
+rtaudio = library('rtaudio', src,
+		soversion: so_version,
+		include_directories: incdir,
+		cpp_args: defines,
+		dependencies: deps,
+		install: true)
 rtaudio_dep = declare_dependency(include_directories : '.',
   link_with : rtaudio)
 meson.override_dependency('rtaudio', rtaudio_dep)


### PR DESCRIPTION
This change lets Meson generate a pkgconfig file that looks like this (edit: removed defines):
```
prefix=/usr/local
libdir=${prefix}/lib64
includedir=${prefix}/include

Name: rtaudio
Description: RtAudio - a set of C++ classes that provide a common API for realtime audio input/output
Version: 5.1.0
Requires.private: alsa, jack, libpulse-simple
Libs: -L${libdir} -lrtaudio
Libs.private: -pthread
Cflags: -I${includedir}/rtaudio
```

It would be quite interesting if Meson adds apple frameworks to Libs.private. Then #302 would be fixed with that (at least for Meson). 

There are two things different to the rtaudio.pc.in file.
1. All dependencies are private because RtAudio doesn't expose any types or API from them.
2. The libdir for Fedora gets correctly set to lib64.

~~RTAUDIO_EXPORT seems to be a Windows thing but it's additionally checked in the header. Should I define that only in Windows?
HAVE_GETTIMEOFDAY is checked in the header. So I thought that would be correct.~~

Edit: After #308 is merged compiler defines shouldn't be necessary anymore. So I removed them completely from the pkgconfig file.

---

This PR also removes the direct libpulse dependency because libpulse-simple seems to be sufficient.