### PR TITLE
Don't repeatedly compute device count when locating default device

### DIFF
--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -411,7 +411,8 @@ void RtApi :: openStream( RtAudio::StreamParameters *oParams,
 unsigned int RtApi :: getDefaultInputDevice( void )
 {
   // Should be reimplemented in subclasses if necessary.
-  for ( unsigned int i = 0; i < getDeviceCount(); i++ ) {
+  unsigned int nDevices = getDeviceCount();
+  for ( unsigned int i = 0; i < nDevices; i++ ) {
     if ( getDeviceInfo( i ).isDefaultInput ) {
       return i;
     }
@@ -423,7 +424,8 @@ unsigned int RtApi :: getDefaultInputDevice( void )
 unsigned int RtApi :: getDefaultOutputDevice( void )
 {
   // Should be reimplemented in subclasses if necessary.
-  for ( unsigned int i = 0; i < getDeviceCount(); i++ ) {
+  unsigned int nDevices = getDeviceCount();
+  for ( unsigned int i = 0; i < nDevices; i++ ) {
     if ( getDeviceInfo( i ).isDefaultOutput ) {
       return i;
     }


### PR DESCRIPTION
Previously, when calling `RtApi::getDefaultInputDevice()` or `RtApi::getDefaultOutputDevice()`, every iteration of the for loop until the default device was found (up to O(n)) would call `getDeviceCount`. On PulseAudio, this would call `RtApiPulse::collectDeviceInfo` and rescan the list of devices (O(n)), resulting in up to O(n^2) runtime with the number of devices. Additionally it could result in tearing where the device count changes midway through the loop.

This changes the code to cache the device count upfront, which shouldn't have any negative effects hopefully.

Tested on PulseAudio and ALSA.

Discovered at https://github.com/thestk/rtaudio/pull/296#issuecomment-890134199.