### PR TITLE
Fix null pointer dereference in rt_pa_server_callback

### DIFF
--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -8504,8 +8504,10 @@ static void rt_pa_server_callback(pa_context *context, const pa_server_info *inf
   (void)data;
   pa_sample_spec ss;
 
-  if (!info)
+  if (!info) {
     rt_pa_mainloop_api_quit(1);
+    return;
+  }
 
   ss = info->sample_spec;
 


### PR DESCRIPTION
This doesn't change behavior in my testing, since I haven't seen `rt_pa_server_callback` get called with a null `const pa_server_info *info`. But it seems the code tries to handle that case, but gets it wrong. rt_pa_mainloop_api_quit doesn't return from the function, it only stops the event loop from running more callbacks, so it's not safe to continue executing the function and dereference `info`.

I'm actually not sure if it's a good idea to overwrite `rt_pa_info` with some value if `info` is null. And I don't know if the value of `rt_pa_mainloop_api_quit(1)` actually gets checked anywhere, or if the error gets lost in transit.