### PR TITLE
Fix bug where PulseAudio devices are randomly not detected

### DIFF
--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -8674,6 +8674,13 @@ void RtApiPulse::collectDeviceInfo( void )
     goto quit;
   }
 
+  if (ret != 0) {
+    errorStream_ << "could not get server info.";
+    errorText_ = errorStream_.str();
+    error( RtAudioError::WARNING );
+    goto quit;
+  }
+
 quit:
   if (context)
     pa_context_unref(context);

--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -8605,7 +8605,8 @@ static void rt_pa_set_source_info_and_quit(pa_context * /*c*/, const pa_source_i
 static void rt_pa_context_state_callback(pa_context *context, void *userdata) {
   (void)userdata;
 
-  switch (pa_context_get_state(context)) {
+  auto state = pa_context_get_state(context);
+  switch (state) {
     case PA_CONTEXT_CONNECTING:
     case PA_CONTEXT_AUTHORIZING:
     case PA_CONTEXT_SETTING_NAME:


### PR DESCRIPTION
For a long time, RtAudio has called `pa_context_get_server_info` which schedules `rt_pa_server_callback` which calls `rt_pa_mainloop_api_quit(0)`. The calls to `pa_context_get_sink_info_list(context, rt_pa_sink_info_cb, NULL)` and `pa_context_get_source_info_list(context, rt_pa_source_info_cb, NULL)` was added later on in c0d33839f522710e5a616a0b5e43d42d95096c7f, but the author forgot to move `rt_pa_mainloop_api_quit(0)` to the last function called (`rt_pa_source_info_cb` with `eol=1`). However, the code still works most of the time by accident: if the PulseAudio server establishes a `pa_srbchannel` connection to the RtAudio app and sends messages fast enough, the client's `pa_mainloop_run` will continue popping sink/source messages from the channel and running `rt_pa_sink_info_cb` and `rt_pa_source_info_cb` in response, before draining the channel and noticing that the mainloop should quit. However this fails randomly when the PulseAudio server fails to send messages faster than RtAudio/`pa_mainloop_run` can process them, resulting in RtAudio randomly not detecting devices. Worse yet, pipewire-pulse doesn't support `pa_srbchannel`, so libpulse will quit `pa_mainloop_run` immediately after `rt_pa_server_callback` is called, failing to detect any devices at all.

This commit moves the call to `rt_pa_mainloop_api_quit(0)` into the last callback (`rt_pa_source_info_cb` with `eol=1`), ensuring devices will never get lost. I also renamed the callback functions to clarify them in my opinion.

In my testing, this fixes the inability to connect to pipewire-pulse ("No audio devices found!"), and fixes random errors on pulseaudio ("RtApi::openStream: output device parameter value is invalid." and "PulseAudio device does not support output.").

Fixes #304.

----

13a0b31fc56d3459caab11655b06336515c9382d is "Print warning when RtApiPulse::collectDeviceInfo() fails". It's affected by #306, and it may be worth quitting the event loop with a different return value based on what caused the failure.