### PR TITLE
Fix header problem with CMake package configuration file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,8 +251,6 @@ if(MSVC AND RTAUDIO_STATIC_MSVCRT)
   endforeach(flag_var)
 endif()
 
-# Add headers destination for install rule.
-set_property(TARGET rtaudio PROPERTY PUBLIC_HEADER RtAudio.h rtaudio_c.h)
 set_target_properties(rtaudio PROPERTIES
   SOVERSION ${SO_VER}
   VERSION ${FULL_VER})
@@ -262,10 +260,10 @@ include(GNUInstallDirs)
 
 # Set include paths, populate target interface.
 target_include_directories(rtaudio
-  INTERFACE
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/rtaudio>
-  PRIVATE
+  PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  PRIVATE
     ${INCDIRS}
 )
 
@@ -300,7 +298,11 @@ install(TARGETS ${LIB_TARGETS}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rtaudio)
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rtaudio)
+
+# Install public header files
+install(FILES RtAudio.h rtaudio_c.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rtaudio)
 
 # Store the package in the user registry.
 export(PACKAGE RtAudio)


### PR DESCRIPTION
Fix #283

I just went for fixing this and I realized there was an issue already opened reporting the same problem.

I tested on macOS and it works. @autoantwort can you give it a try?

EDIT:
Just for completeness, the problem reported in the issue is not exactly the same but it is somehow correlated.
Indeed, I would suggest to use the project like this
```cmake
find_package(RtAudio)
add_exectuable(... PRIVATE RtAudio::rtaudio)
```
specifying the install root path in `RtAudio_ROOT` if needed (as env variable or cmake cache variable).