### PR TITLE
ALSA: rewrite of device listing logic to be more similar to aplay

### DIFF
--- a/RtAudio.h
+++ b/RtAudio.h
@@ -1079,6 +1079,7 @@ public:
 
   std::vector<RtAudio::DeviceInfo> devices_;
   void saveDeviceInfo( void );
+  bool pushDeviceInfo(const char *name, std::vector<RtAudio::DeviceInfo>& devices);
   bool probeDeviceOpen( unsigned int device, StreamMode mode, unsigned int channels, 
                         unsigned int firstChannel, unsigned int sampleRate,
                         RtAudioFormat format, unsigned int *bufferSize,


### PR DESCRIPTION
Uses the same logic as the "aplay" utility that comes with ALSA to get the device list,
with some additional filtering for undesired plugins like "plughw" and "null".

Moreover, the list is saved on first use, or whenever `getDeviceCount()` is called, and
this list is thereafter used to index the device name, which should lead to stable device
selection behaviour.

When devices are initially listed, each device is open-probed to check
availability.  (ALSA errors due to this are suppressed, but it does result in some
messages from the Jack library if the ALSA jack plugin is installed.)

The result is a device list more similar to what is seen in popular software like
Audacity, etc.

I'm curious to hear from people willing to test this or give informed opinions about correct ALSA usage.