### PR TITLE
handle a rare case where wasapi would not return the device name

### DIFF
--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -4505,7 +4505,7 @@ RtAudio::DeviceInfo RtApiWasapi::getDeviceInfo( unsigned int device )
   PropVariantInit( &defaultDeviceNameProp );
 
   hr = defaultDevicePropStore->GetValue( PKEY_Device_FriendlyName, &defaultDeviceNameProp );
-  if ( FAILED( hr ) ) {
+  if ( FAILED( hr ) || defaultDeviceNameProp.pwszVal==nullptr) {
     errorText_ = "RtApiWasapi::getDeviceInfo: Unable to retrieve default device property: PKEY_Device_FriendlyName.";
     goto Exit;
   }
@@ -4522,7 +4522,7 @@ RtAudio::DeviceInfo RtApiWasapi::getDeviceInfo( unsigned int device )
   PropVariantInit( &deviceNameProp );
 
   hr = devicePropStore->GetValue( PKEY_Device_FriendlyName, &deviceNameProp );
-  if ( FAILED( hr ) ) {
+  if ( FAILED( hr ) || deviceNameProp.pwszVal==nullptr) {
     errorText_ = "RtApiWasapi::getDeviceInfo: Unable to retrieve device property: PKEY_Device_FriendlyName.";
     goto Exit;
   }


### PR DESCRIPTION
I encountered a rare case among my beta testers where Windows 10 would return 10 render devices when only 9 were publicly listed in Windows Sound Playback panel. That 10th device seemed to be a ghost device with no name and no user visibility.
As a result, when RtAudio was querying the 10th device name, devicePropStore->GetValue( PKEY_Device_FriendlyName, &deviceNameProp ) returned no error, but deviceNameProp.pwszVal was set to nullptr, which then leaded to a crash.

Making sure that deviceNameProp.pwszVal is not null avoid that crash.
I also added a similar check for defaultDeviceNameProp.pwszVal.

For reference all the details about that crash are in that private beta forum: https://forums.steinberg.net/t/spectralayers-9-0-0-283-not-launching-windows-10/784659/24