### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Several build systems are available.  These are:
   - autotools (`./autogen.sh; make` from git, or `./configure; make` from tarball release)
   - CMake (`mkdir build; cd build; ../cmake; make`)
   - meson (`meson build; cd build; ninja`)
+  - vcpkg (`./bootstrap-vcpkg.sh; ./vcpkg integrate install; ./vcpkg install rtaudio`)
 
 See `install.txt` for more instructions about how to select the audio backend API.  By
 default all detected APIs will be enabled.

--- a/install.txt
+++ b/install.txt
@@ -42,6 +42,19 @@ cd _build_
 cmake <path to CMakeLists.txt usually two dots> <options> e.g. cmake .. -DRTAUDIO_WINDOWS_WASAPI=ON
 
 
+VCPKG USAGE:
+
+You can build and install rtaudio using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh  # ./bootstrap-vcpkg.bat for Windows
+./vcpkg integrate install
+./vcpkg install rtaudio
+
+The rtaudio port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
+
 WINDOWS:
 
 All Windows audio APIs in RtAudio compile with either the MinGW compiler (tested with latest tdm64-gcc-4.8.1) or MS Visual Studio.


### PR DESCRIPTION
Rtaudio is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for rtaudio and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build rtaudio, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/rtaudio/portfile.cmake). We try to keep the library maintained as close as possible to the original library.