### PR TITLE
clamp values when converting from floats

### DIFF
--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -11143,7 +11143,7 @@ void RtApi :: convertBuffer( char *outBuffer, char *inBuffer, ConvertInfo &info 
       for (unsigned int i=0; i<stream_.bufferSize; i++) {
         for (j=0; j<info.channels; j++) {
           // Use llround() which returns `long long` which is guaranteed to be at least 64 bits.
-          out[info.outOffset[j]] = (Int32) std::min(std::llround(in[info.inOffset[j]] * 2147483648.f), 2147483647LL);
+          out[info.outOffset[j]] = (Int32) std::max(std::min(std::llround(in[info.inOffset[j]] * 2147483648.f), 2147483647LL), -2147483648LL);
         }
         in += info.inJump;
         out += info.outJump;
@@ -11153,7 +11153,7 @@ void RtApi :: convertBuffer( char *outBuffer, char *inBuffer, ConvertInfo &info 
       Float64 *in = (Float64 *)inBuffer;
       for (unsigned int i=0; i<stream_.bufferSize; i++) {
         for (j=0; j<info.channels; j++) {
-          out[info.outOffset[j]] = (Int32) std::min(std::llround(in[info.inOffset[j]] * 2147483648.0), 2147483647LL);
+          out[info.outOffset[j]] = (Int32) std::max(std::min(std::llround(in[info.inOffset[j]] * 2147483648.0), 2147483647LL), -2147483648LL);
         }
         in += info.inJump;
         out += info.outJump;
@@ -11210,7 +11210,7 @@ void RtApi :: convertBuffer( char *outBuffer, char *inBuffer, ConvertInfo &info 
       Float32 *in = (Float32 *)inBuffer;
       for (unsigned int i=0; i<stream_.bufferSize; i++) {
         for (j=0; j<info.channels; j++) {
-          out[info.outOffset[j]] = (Int32) std::min(std::llround(in[info.inOffset[j]] * 8388608.f), 8388607LL);
+          out[info.outOffset[j]] = (Int32) std::max(std::min(std::llround(in[info.inOffset[j]] * 8388608.f), 8388607LL), -8388608LL);
         }
         in += info.inJump;
         out += info.outJump;
@@ -11220,7 +11220,7 @@ void RtApi :: convertBuffer( char *outBuffer, char *inBuffer, ConvertInfo &info 
       Float64 *in = (Float64 *)inBuffer;
       for (unsigned int i=0; i<stream_.bufferSize; i++) {
         for (j=0; j<info.channels; j++) {
-          out[info.outOffset[j]] = (Int32) std::min(std::llround(in[info.inOffset[j]] * 8388608.0), 8388607LL);
+          out[info.outOffset[j]] = (Int32) std::max(std::min(std::llround(in[info.inOffset[j]] * 8388608.0), 8388607LL), -8388608LL);
         }
         in += info.inJump;
         out += info.outJump;
@@ -11275,7 +11275,7 @@ void RtApi :: convertBuffer( char *outBuffer, char *inBuffer, ConvertInfo &info 
       Float32 *in = (Float32 *)inBuffer;
       for (unsigned int i=0; i<stream_.bufferSize; i++) {
         for (j=0; j<info.channels; j++) {
-          out[info.outOffset[j]] = (Int16) std::min(std::llround(in[info.inOffset[j]] * 32768.f), 32767LL);
+          out[info.outOffset[j]] = (Int16) std::max(std::min(std::llround(in[info.inOffset[j]] * 32768.f), 32767LL), -32768LL);
         }
         in += info.inJump;
         out += info.outJump;
@@ -11285,7 +11285,7 @@ void RtApi :: convertBuffer( char *outBuffer, char *inBuffer, ConvertInfo &info 
       Float64 *in = (Float64 *)inBuffer;
       for (unsigned int i=0; i<stream_.bufferSize; i++) {
         for (j=0; j<info.channels; j++) {
-          out[info.outOffset[j]] = (Int16) std::min(std::llround(in[info.inOffset[j]] * 32768.0), 32767LL);
+          out[info.outOffset[j]] = (Int16) std::max(std::min(std::llround(in[info.inOffset[j]] * 32768.0), 32767LL), -32768LL);
         }
         in += info.inJump;
         out += info.outJump;
@@ -11339,7 +11339,7 @@ void RtApi :: convertBuffer( char *outBuffer, char *inBuffer, ConvertInfo &info 
       Float32 *in = (Float32 *)inBuffer;
       for (unsigned int i=0; i<stream_.bufferSize; i++) {
         for (j=0; j<info.channels; j++) {
-          out[info.outOffset[j]] = (signed char) std::min(std::llround(in[info.inOffset[j]] * 128.f), 127LL);
+          out[info.outOffset[j]] = (signed char) std::max(std::min(std::llround(in[info.inOffset[j]] * 128.f), 127LL), -128LL);
         }
         in += info.inJump;
         out += info.outJump;
@@ -11349,7 +11349,7 @@ void RtApi :: convertBuffer( char *outBuffer, char *inBuffer, ConvertInfo &info 
       Float64 *in = (Float64 *)inBuffer;
       for (unsigned int i=0; i<stream_.bufferSize; i++) {
         for (j=0; j<info.channels; j++) {
-          out[info.outOffset[j]] = (signed char) std::min(std::llround(in[info.inOffset[j]] * 128.0), 127LL);
+          out[info.outOffset[j]] = (signed char) std::max(std::min(std::llround(in[info.inOffset[j]] * 128.0), 127LL), -128LL);
         }
         in += info.inJump;
         out += info.outJump;


### PR DESCRIPTION
Hi,

I heard artifacts on some songs while using RtAudio to record my PC's audio.

When recording from float formats, it seems that some values can fall out of the expected range.
Adding std::max alongside the existing std::min calls work around the issue.
Let me know if that's not correct.

I'm using macOS 12.6, I don't know if it's specific to CoreAudio.

Repro:
- Install a virtual audio device to record the Mac's audio via `brew install blackhole-2ch`
- Set BlackHole as the default input device
- Run `./tests/record 2 48000 10`
- Play [this song](https://pixabay.com/music/upbeat-bounce-114024/) on Firefox or Safari
- Import and play `record.raw` in audacity (2ch, 48kHz, 16-bit)
- The artifacts can be clearly heard after the 5 seconds

Using soundflower instead of BlackHole lead to the same issue.
Recording the virtual devices via audacity is artifact free (it uses Portaudio).
Chrome and VLC seem to correct the audio themselves, use Safari or Firefox to repro.

![CleanShot 2022-10-17 at 22 35 39](https://user-images.githubusercontent.com/1147807/196278199-64140718-1976-40de-aa57-d528ec495e31.png)

[before.mp4](https://user-images.githubusercontent.com/1147807/196398036-e3612735-6738-49e5-80d1-7ae67b4d86a4.mp4)
[after-fix.mp4](https://user-images.githubusercontent.com/1147807/196398050-8693f2c3-3d71-467d-98d6-8904a8716f2a.mp4)





