### PR TITLE
Subtle problem with WideCharToMultiByte

### DIFF
--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -78,7 +78,8 @@ const unsigned int RtApi::SAMPLE_RATES[] = {
   {
     int length = WideCharToMultiByte(CP_UTF8, 0, text, -1, NULL, 0, NULL, NULL);
     std::string s( length-1, '\0' );
-    WideCharToMultiByte(CP_UTF8, 0, text, -1, &s[0], length, NULL, NULL);
+    if (length > 1)
+        WideCharToMultiByte(CP_UTF8, 0, text, -1, &s[0], length-1, NULL, NULL);
     return s;
   }
 


### PR DESCRIPTION
The use of a std::string as an output buffer when using WideCharToMultiByte leads to a subtle problem. The string buffer length is defined as "length-1". If length == 1, then the expression &s[0] leads to an out of bound assert when debugging since the length of the string buffer is zero. Furthermore, the value "length" is passed to WideCharToMultiByte indicating that you can write "length" bytes to the string buffer, however, the string buffer is only "length-1" bytes long.