### PR TITLE
Asio probe infinite-loop fix.

### DIFF
--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -3370,7 +3370,6 @@ RtApiAsio :: ~RtApiAsio()
 void RtApiAsio :: probeDevices( void )
 {
   // See list of required functionality in RtApi::probeDevices().
-
   unsigned int nDevices = drivers.asioGetNumDev();
   if ( nDevices == 0 ) {
     deviceList_.clear();
@@ -3416,9 +3415,13 @@ void RtApiAsio :: probeDevices( void )
 
   // Asio doesn't provide default devices so call the getDefault
   // functions, which will set the first available input and output
-  // devices as the defaults.
-  getDefaultInputDevice();
-  getDefaultOutputDevice();
+  // devices as the defaults. Don't call getDefaultXXXDevice if
+  // deviceList is empty.
+  if(deviceList_.size() > 0)
+  {
+    getDefaultInputDevice();
+    getDefaultOutputDevice();
+  }
 }
 
 bool RtApiAsio :: probeDeviceInfo( RtAudio::DeviceInfo &info )


### PR DESCRIPTION
The problem: when my ASIO device is unplugged (driver still installed), deviceProbe finds no devices which results in an infinite loop when `RtApiAsio :: probeDevices` invokes getDefaultInputDevice() - which re-invokes  RtApiAsio :: probeDevices.  This problem can be reproduced by running the standard audioprobe test.

In this condition `probeDeviceInfo( info ) == false` around line 3406.

I'm not claiming that my fix is the best fix but have verified that it unclogs the logjam.
