### PR TITLE
fix rtaudio_get_device_info

### DIFF
--- a/rtaudio_c.cpp
+++ b/rtaudio_c.cpp
@@ -89,12 +89,12 @@ unsigned int rtaudio_get_device_id(rtaudio_t audio, int i) {
     return 0;
 }
 
-rtaudio_device_info_t rtaudio_get_device_info(rtaudio_t audio, int i) {
+rtaudio_device_info_t rtaudio_get_device_info(rtaudio_t audio, unsigned int id) {
   rtaudio_device_info_t result;
   std::memset(&result, 0, sizeof(result));
 
   audio->errtype = RTAUDIO_ERROR_NONE;
-  RtAudio::DeviceInfo info = audio->audio->getDeviceInfo(i);
+  RtAudio::DeviceInfo info = audio->audio->getDeviceInfo(id);
   if (audio->errtype != RTAUDIO_ERROR_NONE)
       return result;
 

--- a/rtaudio_c.h
+++ b/rtaudio_c.h
@@ -246,10 +246,10 @@ RTAUDIOAPI int rtaudio_device_count(rtaudio_t audio);
 //! RtAudio::getDeviceIds().
 RTAUDIOAPI unsigned int rtaudio_get_device_id(rtaudio_t audio, int i);
 
-//! Return a struct rtaudio_device_info for a specified device number.
+//! Return a struct rtaudio_device_info for a specified device ID.
 //! See \ref RtAudio::getDeviceInfo().
 RTAUDIOAPI rtaudio_device_info_t rtaudio_get_device_info(rtaudio_t audio,
-                                                         int i);
+                                                         unsigned int id);
 
 //! Returns the device id of the default output device.  See \ref
 //! RtAudio::getDefaultOutputDevice().


### PR DESCRIPTION
I noticed another error with the c headers. The `rtaudio_get_device_info` function needs the device ID, not the index.