### PR TITLE
Move include(CTest) to inside testing guard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,12 +280,12 @@ target_compile_definitions(rtaudio PRIVATE RTAUDIO_EXPORT)
 target_link_libraries(rtaudio ${LINKLIBS})
 
 # Subdirs
-include(CTest)
 
 if (NOT DEFINED RTAUDIO_BUILD_TESTING OR RTAUDIO_BUILD_TESTING STREQUAL "")
   set(RTAUDIO_BUILD_TESTING ${BUILD_TESTING})
 endif()
 if (RTAUDIO_BUILD_TESTING)
+  include(CTest)
   add_subdirectory(tests)
 endif()
 


### PR DESCRIPTION
The RTAUDIO_BUILD_TESTING variable stops the testing target ejection but still does an include(CTest) which injects the standard CTest macros from enable_testing(). In rtmidi you include(CTest) inside the guard but in rtaudio you do not; as such using the cmake in a non-ctest project ejects multiple targets.

For now you can get around this with BUILD_TESTING globally off but that means you can't activate your own ctests optionally.

So move the include(CTEst) to be in the same spot as it is in rtmidi.

Thanks for great software!