### PR TITLE
Remove CoreAudio device disconnect listener when closing input mode streams

### DIFF
--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -1981,7 +1981,7 @@ void RtApiCore :: closeStream( void )
         }
       }
 
-      if ( handle->disconnectListenerAdded[0] ) {
+      if ( handle->disconnectListenerAdded[1] ) {
         property.mSelector = kAudioDevicePropertyDeviceIsAlive;
         if (AudioObjectRemovePropertyListener( handle->id[1], &property, streamDisconnectListener, (void *) &stream_.callbackInfo ) != noErr) {
           errorText_ = "RtApiCore::closeStream(): error removing disconnect property listener!";


### PR DESCRIPTION
The flag handle->disconnectListenerAdded[0] is never set to true for input mode streams because the probeOpenStream() code uses handle->disconnectListenerAdded[mode].

This causes RtAudio to never remove device disconnect listeners, which can cause the listener slots to fill up and an "illegal instruction" error code to be returned when you try to add a new one.