### PR TITLE
Use correct number of channels for the selected CoreAudio stream

### DIFF
--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -1782,7 +1782,7 @@ bool RtApiCore :: probeDeviceOpen( unsigned int deviceId, StreamMode mode, unsig
   stream_.deviceFormat[mode] = RTAUDIO_FLOAT32;
 
   if ( streamCount == 1 )
-    stream_.nDeviceChannels[mode] = description.mChannelsPerFrame;
+    stream_.nDeviceChannels[mode] = streamChannels;
   else // multiple streams
     stream_.nDeviceChannels[mode] = channels;
   stream_.nUserChannels[mode] = channels;


### PR DESCRIPTION
The `kAudioStreamPropertyPhysicalFormat` query returns the number of channels for the device's first audio stream. If any single, subsequent stream is selected to fulfill the user request, it may use a different number of channels. This mismatch can cause a lot of problems.