### PR TITLE
Fix Windows deprecation warnings using WideCharToMultiByte()

### DIFF
--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -74,7 +74,22 @@ std::string convertCharPointerToStdString(const char *text)
 template<> inline
 std::string convertCharPointerToStdString(const wchar_t *text)
 {
+#if 1
+  if (!text)
+    return std::string();
+  const int wchars = (int) wcslen(text);
+  // how many characters are required after conversion?
+  const int nchars = WideCharToMultiByte(CP_UTF8, 0, text, wchars, 0, 0, 0, 0);
+  if (!nchars)
+    return std::string();
+  // create buffer
+  std::string nret(nchars, 0);
+  // do the conversion
+  WideCharToMultiByte(CP_UTF8, 0, text, wchars, &nret[0], nchars, 0, 0);
+  return nret;
+#else
   return std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>>{}.to_bytes(text);
+#endif
 }
 
 #if defined(_MSC_VER)

--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -74,7 +74,7 @@ std::string convertCharPointerToStdString(const char *text)
 template<> inline
 std::string convertCharPointerToStdString(const wchar_t *text)
 {
-#if 1
+#if defined(_MSC_VER)
   if (!text)
     return std::string();
   const int wchars = (int) wcslen(text);


### PR DESCRIPTION
This PR is for review. It is not final. Please add any comments and I'll adjust accordingly.