### PR TITLE
Missing delete of struct rtaudio in rtaudio_destroy() (C api)

### DIFF
--- a/rtaudio_c.cpp
+++ b/rtaudio_c.cpp
@@ -71,7 +71,7 @@ rtaudio_t rtaudio_create(rtaudio_api_t api) {
   return audio;
 }
 
-void rtaudio_destroy(rtaudio_t audio) { delete audio->audio; }
+void rtaudio_destroy(rtaudio_t audio) { delete audio->audio; delete audio; }
 
 rtaudio_api_t rtaudio_current_api(rtaudio_t audio) {
   return (rtaudio_api_t)audio->audio->getCurrentApi();


### PR DESCRIPTION
In the C API, the destruction of `struct rtaudio` is missing in the function `rtaudio_destroy(`).
GCC/Clang leak sanitizers detected this.