### PR TITLE
allow RtAudio to be installed with FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Set minimum CMake required version for this project.
-cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
 # Define a C++ project.
 project(RtAudio LANGUAGES CXX)
@@ -343,8 +343,8 @@ write_basic_package_version_file(
 
 install(
   FILES
-    ${CMAKE_BINARY_DIR}/RtAudioConfig.cmake
-    ${CMAKE_BINARY_DIR}/RtAudioConfig-version.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/RtAudioConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/RtAudioConfig-version.cmake
   DESTINATION
     ${RTAUDIO_CMAKE_DESTINATION}
 )


### PR DESCRIPTION
This is just to fix a little inconsistency that may put the `RtAudioConfig.cmake` and `RtAudioConfig-version.cmake` in the wrong folders when installing: when using RtAudio as a submodule or with CMake's `FetchContent`.

`CMAKE_CURRENT_BINARY_DIR` is already being used in other places in the same `CMakeLists.txt` file (see from https://github.com/thestk/rtaudio/blob/af3b361aee64a12aad0e7fea2dc2e2bf406a9ec4/CMakeLists.txt#L322 on).

Thanks!