### PR TITLE
S24: change storage to 4 chars

### DIFF
--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -10911,12 +10911,10 @@ unsigned int RtApi :: formatBytes( RtAudioFormat format )
 {
   if ( format == RTAUDIO_SINT16 )
     return 2;
-  else if ( format == RTAUDIO_SINT32 || format == RTAUDIO_FLOAT32 )
+  else if ( format == RTAUDIO_SINT32 || format == RTAUDIO_FLOAT32 || format == RTAUDIO_SINT24)
     return 4;
   else if ( format == RTAUDIO_FLOAT64 )
     return 8;
-  else if ( format == RTAUDIO_SINT24 )
-    return 3;
   else if ( format == RTAUDIO_SINT8 )
     return 1;
 

--- a/RtAudio.h
+++ b/RtAudio.h
@@ -711,7 +711,7 @@ struct CallbackInfo {
 class S24 {
 
  protected:
-  unsigned char c3[3];
+  unsigned char c3[4];
 
  public:
   S24() {}

--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@ AM_INIT_AUTOMAKE([1.14 -Wall -Werror foreign subdir-objects])
 #
 # If any interfaces have been removed since the last public release, then set
 # age to 0.
-m4_define([lt_current], 7)
+m4_define([lt_current], 8)
 m4_define([lt_revision], 0)
 m4_define([lt_age], 0)
 


### PR DESCRIPTION
This is required (at least on my system (aarch64, gcc 14.1.1)) because
    the convertBuffer function is expecting arrays of S24 to increment
    at the same rate as arrays of S32; without this change, when a S24*
    pointer increments, it increases by 3 instead of 4 on my system,
    causing garbled audio output.

    Since this very minor change is an interface change, I have bumped
    the version number.