### PR TITLE
New Feature: Buffer size and sample rate callback functions

### DIFF
--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -2919,9 +2919,15 @@ bool RtApiJack :: probeDeviceOpen( unsigned int deviceId, StreamMode mode, unsig
 
   // Get the buffer size.  The buffer size and number of buffers
   // (periods) is set when the jack server is started.
-  stream_.bufferSize = (int) jack_get_buffer_size( client );
-  *bufferSize = stream_.bufferSize;
-
+  // If the requested buffer_size for the stream is different, 
+  // force the jack or pipewire-jack server to use the requested
+  // buffersize for all clients.
+  if ( *bufferSize != (unsigned int) jack_get_buffer_size( client ) ) {
+    std::cout << "RtApiJack::probeDeviceOpen: JACK server buffer size is different than the requested buffer size - forcing requested buffer size for all clients." << std::endl;
+    jack_set_buffer_size( client, (jack_nframes_t) *bufferSize );
+  }
+  
+  stream_.bufferSize = *bufferSize;
   stream_.nDeviceChannels[mode] = channels;
   stream_.nUserChannels[mode] = channels;
 

--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -183,6 +183,16 @@ public:
   // which is not a member of RtAudio.  External use of this function
   // will most likely produce highly undesirable results!
   bool callbackEvent( unsigned long nframes );
+  
+  // This function is intended for internal use only.  It must be
+  // public because it is called by the internal buffer size callback
+  // handler, which is not a member of RtAudio.
+  bool bufferSizeCallbackEvent( unsigned long nframes );
+
+  // This function is intended for internal use only.  It must be
+  // public because it is called by the internal sample rate callback
+  // handler, which is not a member of RtAudio.
+  bool sampleRateCallbackEvent( unsigned long sampleRate );
 
   private:
   void probeDevices( void ) override;
@@ -762,6 +772,12 @@ RtAudioErrorType RtApi :: openStream( RtAudio::StreamParameters *oParams,
 
   stream_.callbackInfo.callback = (void *) callback;
   stream_.callbackInfo.userData = userData;
+
+  stream_.bufferSizeCallbackInfo.callback = (void *) options->bufferSizeCallback;
+  stream_.bufferSizeCallbackInfo.userData = options->bufferSizeCallbackUserData;
+
+  stream_.sampleRateCallbackInfo.callback = (void *) options->sampleRateCallback;
+  stream_.sampleRateCallbackInfo.userData = options->sampleRateCallbackUserData;
 
   if ( options ) options->numberOfBuffers = stream_.nBuffers;
   stream_.state = STREAM_STOPPED;
@@ -2736,6 +2752,24 @@ static int jackCallbackHandler( jack_nframes_t nframes, void *infoPointer )
   return 0;
 }
 
+static int jackBufferSizeCallbackHandler( jack_nframes_t nframes, void *infoPointer )
+{
+  CallbackInfo *info = (CallbackInfo *) infoPointer;
+
+  RtApiJack *object = (RtApiJack *) info->object;
+  if ( object->bufferSizeCallbackEvent( (unsigned long) nframes ) == false ) return 1;
+  return 0;
+}
+
+static int jackSampleRateCallbackHandler( jack_nframes_t nframes, void *infoPointer )
+{
+  CallbackInfo *info = (CallbackInfo *) infoPointer;
+
+  RtApiJack *object = (RtApiJack *) info->object;
+  if ( object->sampleRateCallbackEvent( (unsigned long) nframes ) == false ) return 1;
+  return 0;
+}
+
 // This function will be called by a spawned thread when the Jack
 // server signals that it is shutting down.  It is necessary to handle
 // it this way because the jackShutdown() function must return before
@@ -2968,6 +3002,8 @@ bool RtApiJack :: probeDeviceOpen( unsigned int deviceId, StreamMode mode, unsig
   else {
     stream_.mode = mode;
     jack_set_process_callback( handle->client, jackCallbackHandler, (void *) &stream_.callbackInfo );
+    jack_set_buffer_size_callback( handle->client, jackBufferSizeCallbackHandler, (void *) &stream_.callbackInfo);
+    jack_set_sample_rate_callback( handle->client, jackSampleRateCallbackHandler, (void *) &stream_.callbackInfo);
     jack_set_xrun_callback( handle->client, jackXrun, (void *) &stream_.apiHandle );
     jack_on_shutdown( handle->client, jackShutdown, (void *) &stream_.callbackInfo );
     //jack_set_client_registration_callback( handle->client, jackClientChange, (void *) &stream_.callbackInfo );
@@ -3323,6 +3359,90 @@ bool RtApiJack :: callbackEvent( unsigned long nframes )
   RtApi::tickStreamTime();
   return SUCCESS;
 }
+
+bool RtApiJack :: bufferSizeCallbackEvent ( unsigned long nframes )
+{
+  if ( stream_.bufferSize == (unsigned int) nframes ) return true;
+
+  bool isRunning = stream_.state == STREAM_RUNNING;
+  if ( isRunning ) {
+    jack_client_t *client = ((JackHandle *) stream_.apiHandle)->client;
+    std::cout << "bufferSizeCallbackEvent: stopping stream." << std::endl;
+    jack_deactivate( client );
+    std::cout << "Client deactivated" << std::endl;
+    stream_.state = STREAM_STOPPED;
+  }
+  // Set the new buffer size
+  stream_.bufferSize = (unsigned int) nframes;
+
+  // TODO - Adapt for all modes
+  int mode = stream_.mode;
+
+  // Allocate necessary internal buffers.
+  unsigned long bufferBytes;
+  bufferBytes = stream_.nUserChannels[mode] * stream_.bufferSize * formatBytes( stream_.userFormat );
+
+  if ( stream_.userBuffer[mode] ) free( stream_.userBuffer[mode] );
+  stream_.userBuffer[mode] = (char *) calloc( bufferBytes, 1 );
+  if ( stream_.userBuffer[mode] == NULL ) {
+    errorText_ = "RtApiJack::probeDeviceOpen: error allocating user buffer memory.";
+  }
+
+  if ( stream_.doConvertBuffer[mode] ) {
+    
+    bool makeBuffer = true;
+    if ( mode == OUTPUT )
+      bufferBytes = stream_.nDeviceChannels[0] * formatBytes( stream_.deviceFormat[0] );
+    else { // mode == INPUT
+      bufferBytes = stream_.nDeviceChannels[1] * formatBytes( stream_.deviceFormat[1] );
+      if ( stream_.mode == OUTPUT && stream_.deviceBuffer ) {
+        unsigned long bytesOut = stream_.nDeviceChannels[0] * formatBytes(stream_.deviceFormat[0]);
+        if ( bufferBytes < bytesOut ) makeBuffer = false;
+      }
+    }
+
+    if ( makeBuffer ) {
+      bufferBytes *= stream_.bufferSize;
+      if ( stream_.deviceBuffer ) free( stream_.deviceBuffer );
+      stream_.deviceBuffer = (char *) calloc( bufferBytes, 1 );
+      if ( stream_.deviceBuffer == NULL ) {
+        errorText_ = "RtApiJack::probeDeviceOpen: error allocating device buffer memory.";
+      }
+    }
+  }
+
+  BufferSizeCallbackInfo *info = (BufferSizeCallbackInfo *) &stream_.bufferSizeCallbackInfo;
+
+  if ( info->callback ) {
+    RtAudioBufferSizeCallback callback = (RtAudioBufferSizeCallback) info->callback;
+    if ( callback ) {
+      callback( &stream_.bufferSize, info->userData );
+    }
+  }
+
+  if ( isRunning ) {
+    startStream();
+  }
+
+  return true;
+}
+
+bool RtApiJack :: sampleRateCallbackEvent ( unsigned long sampleRate )
+{
+  if ( stream_.sampleRate == (unsigned int) sampleRate ) return true;
+  else {
+    stream_.sampleRate = (unsigned int) sampleRate;
+    SampleRateCallbackInfo *info = (SampleRateCallbackInfo *) &stream_.sampleRateCallbackInfo;
+    if ( info->callback ) {
+      RtAudioSampleRateCallback callback = (RtAudioSampleRateCallback) info->callback;
+      if ( callback ) {
+        callback( &stream_.sampleRate, info->userData );
+      }
+    }
+  }
+  return true;
+}
+
   //******************** End of __UNIX_JACK__ *********************//
 #endif
 

--- a/RtAudio.h
+++ b/RtAudio.h
@@ -230,7 +230,8 @@ typedef int (*RtAudioCallback)( void *outputBuffer, void *inputBuffer,
     This function type is used to specify a callback function that
     will be invoked when the system buffer size changes.  This only
     occurs when a stream is utilizing a native API that allows
-    dynamic buffer resizing (for now only JACK/Pipewire-JACK).
+    dynamic buffer resizing (i.e., ASIO, JACK). At the moment, this
+    is only implemented for the JACK API.
 
     \param bufferSize The current system buffer size in sample frames.
 
@@ -238,6 +239,7 @@ typedef int (*RtAudioCallback)( void *outputBuffer, void *inputBuffer,
            when opening the stream (default = NULL). This data is set 
            by the user in the RtAudio::StreamOptions structure when
             calling the RtAudio::openStream() function.
+            
     \return 0 to continue normal stream operation, 1 to stop the stream
             and drain the output buffer, or 2 to abort the stream
             immediately.
@@ -249,14 +251,17 @@ typedef int (*RtAudioBufferSizeCallback)( unsigned int *bufferSize, void *userDa
     This function type is used to specify a callback function that
     will be invoked when the system sample rate changes.  This only
     occurs when a stream is utilizing a native API that allows
-    dynamic sample rate changes (for now only JACK/Pipewire-JACK).
+    dynamic sample rate changes (i.e., ASIO, JACK). At the moment, this
+    is only implemented for the JACK API.
 
-    \param sampleRate The current system sample rate in sample frames per second.
+    \param sampleRate The current system sample rate in sample frames
+    per second.
 
     \param userData A pointer to optional data provided by the client
            when opening the stream (default = NULL). This data is set 
            by the user in the RtAudio::StreamOptions structure when
             calling the RtAudio::openStream() function.
+
     \return 0 to continue normal stream operation, 1 to stop the stream
             and drain the output buffer, or 2 to abort the stream
             immediately.
@@ -402,6 +407,38 @@ class RTAUDIO_DLL_PUBLIC RtAudio
     However, if you wish to create multiple instances of RtAudio with
     Jack, each instance must have a unique client name. The default
     Pulse application name is set to "RtAudio."
+
+    The \c bufferSizeCallback parameter can be used to set a function
+    that will be called when the system buffer size changes. This only
+    occurs when a stream is utilizing a native API that allows dynamic
+    buffer resizing (i.e., ASIO, JACK). At the moment, this is only
+    implemented for the JACK API. The function should have the 
+    following signature:
+    \c int (*callback)(unsigned int *bufferSize, void *userData).
+    The \c bufferSize parameter will be set to the current system buffer
+    size in sample frames. If the stream is open, the return value will
+    control the behavior of the stream. The function should return 0 to
+    continue normal stream operation, 1 to stop the stream and drain the
+    output buffer, or 2 to abort the stream immediately. The \c userData
+    parameter is an optional pointer to data that can be passed with the
+    \c bufferSizeCallbackUserData parameter, which will be passed to the
+    callback function.
+
+    The \c sampleRateCallback parameter can be used to set a function
+    that will be called when the system sample rate changes. This only
+    occurs when a stream is utilizing a native API that allows dynamic
+    sample rate changes (i.e., ASIO, JACK). At the moment, this is only
+    implemented for the JACK API. The function should have the
+    following signature:
+    \c int (*callback)(unsigned int *sampleRate, void *userData).
+    The \c sampleRate parameter will be set to the current system sample
+    rate in sample frames per second. If the stream is open, the return
+    value will control the behavior of the stream. The function should
+    return 0 to continue normal stream operation, 1 to stop the stream
+    and drain the output buffer, or 2 to abort the stream immediately.
+    The \c userData parameter is an optional pointer to data that can be
+    passed with the \c sampleRateCallbackUserData parameter, which will
+    be passed to the callback function.
   */
   struct StreamOptions {
     RtAudioStreamFlags flags{};      /*!< A bit-mask of stream flags (RTAUDIO_NONINTERLEAVED, RTAUDIO_MINIMIZE_LATENCY, RTAUDIO_HOG_DEVICE, RTAUDIO_ALSA_USE_DEFAULT). */


### PR DESCRIPTION
Some native APIs allow for dynamic buffer size and sample rate changes (i.e. JACK/Pipewire-JACK). This PR adds the ability to set callback functions for buffer size and sample rate changes that occur during stream operation. The callback functions are specified in the `RtAudio::StreamOptions` struct and are called when the buffer size or sample rate changes. The callback functions are backend agnostic and are implemented for the JACK backend in this PR.

Internally the `RtApiStream` gets two new members, `bufferSizeCallbackInfo` and `sampleRateCallbackInfo` similar to the existing `callbackInfo` member. The `BufferSizeCallbackInfo` and `SampleRateCallbackInfo` structs are populated when the `RtAudio::openStream` function is called. The user can specify the respective callback functions pointers (`RtAudioBufferSizeCallback` or/and an `RtAudioSampleRateCallback`) and user data pointers (`void*`) in the `RtAudio::StreamOptions` struct. The `RtAudio::StreamOptions` are therefore extended with the following members:

- `bufferSizeCallback` of type `RtAudioBufferSizeCallback`
- `bufferSizeCallbackUserData` of type `void*`
- `sampleRateCallback` of type `RtAudioSampleRateCallback`
- `sampleRateCallbackUserData` of type `void*`

When specified, the respective callback functions are called, when the buffer size or sample rate changes. Additionally, the following internal `RtApiStream` members are updated when the buffer size changes:

- `bufferSize`
- `userBuffer` is reallocated with the new buffer size
- `deviceBuffer` is reallocated with the new buffer size

When the sample rate changes, only the `sampleRate` member is updated.

This is all implemented with the JACK backend, but the changes are designed to be backend agnostic, so that other backends can be extended in the future.

I would appreciate feedback and would be happy to make any necessary changes to get this PR merged.

Cheers,
Fares

PS: I have also added the ability for the JACK backend to force a buffer size on the JACK server with `jack_set_buffer_size()` when the stream is opened and the requested buffer size from the stream is different from the current JACK server buffer size. This happens automatically, but a warning is printed to the console. To me this seems better than the current behavior where the buffer size of the JACK server is queried and the stream is simply opened with the JACK server buffer size.