### PR TITLE
Replace inline namespace with implicitly imported namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ RtAudio is a set of C++ classes that provides a common API (Application Programm
 
 RtAudio incorporates the concept of audio streams, which represent audio output (playback) and/or input (recording).  Available audio devices and their capabilities can be enumerated and then specified when opening a stream.  Where applicable, multiple API support can be compiled and a particular API specified when creating an RtAudio instance.  See the \ref apinotes section for information specific to each of the supported audio APIs.
 
-RtAudio is also offered as a module, which is enabled with `RTAUDIO_BUILD_MODULES`, and is accessed with `import rt.audio;`. Namespaces are inlined, so classes can be accessed through namespace `rt::audio` or through the global namespace (for example, `rt::audio::RtApi` and `::RtApi` are both valid).
+RtAudio is also offered as a module, which is enabled with `RTAUDIO_BUILD_MODULES`, and is accessed with `import rt.audio;`. Namespaces are implicitly imported (unless disabled with `RTAUDIO_USE_NAMESPACE`), so classes can be accessed through namespace `rt::audio` or through the global namespace (for example, `rt::audio::RtApi` and `::RtApi` are both valid).
 
 ## Building
 

--- a/RtAudio.cpp
+++ b/RtAudio.cpp
@@ -55,6 +55,8 @@
 #include <windows.h>
 #endif
 
+using namespace rt::audio;
+
 // Static variable definitions.
 const unsigned int RtApi::MAX_SAMPLE_RATES = 14;
 const unsigned int RtApi::SAMPLE_RATES[] = {

--- a/RtAudio.h
+++ b/RtAudio.h
@@ -85,8 +85,7 @@
 #include <functional>
 #include <memory>
 
-inline namespace rt {
-inline namespace audio {
+namespace rt::audio {
 
 /*! \typedef typedef unsigned long RtAudioFormat;
     \brief RtAudio data format type.
@@ -652,7 +651,6 @@ class RTAUDIO_DLL_PUBLIC RtAudio
 };
 
 }
-}
 
 // Operating system dependent thread functionality.
 #if defined(_MSC_VER)
@@ -676,11 +674,9 @@ inline namespace audio {
   // Using pthread library for various flavors of unix.
   #include <pthread.h>
 
-inline namespace rt {
-inline namespace audio {
+namespace rt::audio {
   typedef pthread_t ThreadHandle;
   typedef pthread_mutex_t StreamMutex;
-}
 }
 
 #endif
@@ -694,8 +690,7 @@ inline namespace audio {
 
 #endif
 
-inline namespace rt {
-inline namespace audio {
+namespace rt::audio {
 
 // This global structure type is used to pass callback information
 // between the private RtAudio stream structure and global callback
@@ -756,7 +751,6 @@ class S24 {
 #pragma pack(pop)
 
 }
-}
 
 #if defined( HAVE_GETTIMEOFDAY )
   #include <sys/time.h>
@@ -764,8 +758,7 @@ class S24 {
 
 #include <sstream>
 
-inline namespace rt {
-inline namespace audio {
+namespace rt::audio {
 
 class RTAUDIO_DLL_PUBLIC RtApi
 {
@@ -953,10 +946,12 @@ inline void RtAudio :: setErrorCallback( RtAudioErrorCallback errorCallback ) { 
 inline void RtAudio :: showWarnings( bool value ) { rtapi_->showWarnings( value ); }
 
 }
-}
 
 #endif
 
+#ifndef RTAUDIO_USE_NAMESPACE
+using namespace rt::audio;
+#endif
 
 // Indentation settings for Vim and Emacs
 //

--- a/modules/RtAudio.cppm
+++ b/modules/RtAudio.cppm
@@ -4,13 +4,7 @@ module;
 
 export module rt.audio;
 
-export
-#ifndef RTAUDIO_USE_NAMESPACE
-inline namespace rt {
-inline namespace audio {
-#else
-namespace rt::audio {
-#endif
+export namespace rt::audio {
     using rt::audio::RtAudioFormat;
     using rt::audio::RtAudioStreamFlags;
     using rt::audio::RtAudioStreamStatus;
@@ -24,6 +18,7 @@ namespace rt::audio {
     using rt::audio::CallbackInfo;
     using rt::audio::S24;
 }
+
 #ifndef RTAUDIO_USE_NAMESPACE
-}
+using namespace rt::audio;
 #endif


### PR DESCRIPTION
This pull request replaces `inline namespace` with a strict `namespace`, which avoids additional preprocessor logic in the module file, and adds `using namespace rt::audio;` unless `RTAUDIO_USE_NAMESPACE` is enabled (to avoid breaking code that accesses `rt::audio` classes through the global namespace).