### PR TITLE
remove nested namespace definitions to maintain compatibility with C++11

### DIFF
--- a/RtAudio.h
+++ b/RtAudio.h
@@ -85,7 +85,8 @@
 #include <functional>
 #include <memory>
 
-namespace rt::audio {
+namespace rt {
+namespace audio {
 
 /*! \typedef typedef unsigned long RtAudioFormat;
     \brief RtAudio data format type.
@@ -650,7 +651,8 @@ class RTAUDIO_DLL_PUBLIC RtAudio
   std::shared_ptr<RtApi> rtapi_;
 };
 
-}
+} // namespace audio
+} // namespace rt
 
 // Operating system dependent thread functionality.
 #if defined(_MSC_VER)
@@ -662,22 +664,24 @@ class RTAUDIO_DLL_PUBLIC RtAudio
   #include <process.h>
   #include <stdint.h>
 
-inline namespace rt {
-inline namespace audio {
+namespace rt {
+namespace audio {
   typedef uintptr_t ThreadHandle;
   typedef CRITICAL_SECTION StreamMutex;
-}
-}
+} // namespace audio
+} // namespace rt
 
 #else
 
   // Using pthread library for various flavors of unix.
   #include <pthread.h>
 
-namespace rt::audio {
+namespace rt {
+namespace audio {
   typedef pthread_t ThreadHandle;
   typedef pthread_mutex_t StreamMutex;
-}
+} // namespace audio
+} // namespace rt
 
 #endif
 
@@ -690,7 +694,8 @@ namespace rt::audio {
 
 #endif
 
-namespace rt::audio {
+namespace rt {
+namespace audio {
 
 // This global structure type is used to pass callback information
 // between the private RtAudio stream structure and global callback
@@ -750,7 +755,8 @@ class S24 {
 };
 #pragma pack(pop)
 
-}
+} // namespace audio
+} // namespace rt
 
 #if defined( HAVE_GETTIMEOFDAY )
   #include <sys/time.h>
@@ -758,7 +764,8 @@ class S24 {
 
 #include <sstream>
 
-namespace rt::audio {
+namespace rt {
+namespace audio {
 
 class RTAUDIO_DLL_PUBLIC RtApi
 {
@@ -945,7 +952,8 @@ inline void RtAudio :: setStreamTime( double time ) { return rtapi_->setStreamTi
 inline void RtAudio :: setErrorCallback( RtAudioErrorCallback errorCallback ) { rtapi_->setErrorCallback( errorCallback ); }
 inline void RtAudio :: showWarnings( bool value ) { rtapi_->showWarnings( value ); }
 
-}
+} // namespace audio
+} // namespace rt
 
 #endif
 


### PR DESCRIPTION
in reference to issue #469 

mentioning @mikomikotaishi since it reverts part of your change