### PR TITLE
Fix ghost ASIO driver hang by validating HFILE properly

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -1,0 +1,16 @@
+# Local Patches
+
+This fork (`groundhog-audio/rtaudio`) carries the following deviations from
+upstream `thestk/rtaudio`:
+
+## Fix ghost ASIO driver hang by validating HFILE properly
+
+**File:** `include/asiolist.cpp`
+
+The bundled ASIO SDK shim used `if (hfile)` to validate the result of the
+Win16 `OpenFile()` API. `OpenFile` returns `HFILE_ERROR` (`-1`) on failure,
+which is truthy, so ghost/invalid ASIO driver registry entries (left behind
+by uninstalled audio software) passed the check and caused
+`loadAsioDriver` to hang the application indefinitely during device
+enumeration. Changed to `if (hfile && hfile != HFILE_ERROR)` to reject both
+sentinels explicitly (matches the documented Win16 API contract).

--- a/include/asiolist.cpp
+++ b/include/asiolist.cpp
@@ -39,7 +39,7 @@ static LONG findDrvPath (char *clsidstr,char *dllpath,int dllpathsize)
 								memset(&ofs,0,sizeof(OFSTRUCT));
 								ofs.cBytes = sizeof(OFSTRUCT); 
 								hfile = OpenFile(dllpath,&ofs,OF_EXIST);
-								if (hfile) rc = 0; 
+								if (hfile && hfile != HFILE_ERROR) rc = 0; 
 							}
 							RegCloseKey(hkpath);
 						}
@@ -69,7 +69,7 @@ static LONG findDrvPath (char *clsidstr,char *dllpath,int dllpathsize)
 								memset(&ofs,0,sizeof(OFSTRUCT));
 								ofs.cBytes = sizeof(OFSTRUCT); 
 								hfile = OpenFile(dllpath,&ofs,OF_EXIST);
-								if (hfile) rc = 0; 
+								if (hfile && hfile != HFILE_ERROR) rc = 0; 
 							}
 							RegCloseKey(hkpath);
 						}


### PR DESCRIPTION
OpenFile returns HFILE_ERROR (-1) on failure, which the previous check (if (hfile)) incorrectly accepted as a valid handle. This caused ghost ASIO driver entries (left behind by uninstalled software) to pass validation and hang the app when rtaudio tried to load them. Use (hfile && hfile != HFILE_ERROR) to reject both sentinels explicitly.