### PR TITLE
[CMake|WIN32] Add a custom command to copy the DLL in the tests directory

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,12 +1,26 @@
 include_directories(..)
 if (WIN32)
     include_directories(../include)
+
+    function(copy_runtime_deps target)
+        if (WIN32)
+            add_custom_command(
+                TARGET ${target}
+                POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    $<TARGET_RUNTIME_DLLS:${target}>
+                    $<TARGET_FILE_DIR:${target}>
+                COMMAND_EXPAND_LISTS
+            )
+        endif()
+    endfunction()
 endif (WIN32)
 
 list(GET LIB_TARGETS 0 LIBRTAUDIO)
 
 add_executable(audioprobe audioprobe.cpp)
 target_link_libraries(audioprobe ${LIBRTAUDIO} ${LINKLIBS})
+copy_runtime_deps(audioprobe) # just one to copy the dll in the tests/ dir
 
 add_executable(playsaw playsaw.cpp)
 target_link_libraries(playsaw ${LIBRTAUDIO} ${LINKLIBS})


### PR DESCRIPTION
This should Fix #483 